### PR TITLE
Fix duplicate call notifications across processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ cosmic-ext-connected/
 ├── cosmic-ext-connected/src/
 │   ├── app.rs              # Core: ConnectApplet, Message enum, update()
 │   ├── config.rs           # User preferences (cosmic_config)
+│   ├── notifications.rs    # Cross-process notification deduplication
 │   ├── subscriptions.rs    # D-Bus signal subscriptions
 │   ├── device/             # Device fetch and actions
 │   ├── sms/                # SMS conversations, views, subscriptions


### PR DESCRIPTION
## Summary
- Add cross-process deduplication for call notifications using the same file-based locking pattern already used for SMS and file notifications
- COSMIC spawns multiple applet processes that each independently receive the D-Bus `callReceived` signal, causing 3 identical desktop notifications per incoming call
- New `should_show_call_notification()` function uses `"{event}:{phone_number}"` as the dedup key so distinct events (e.g. `callReceived` vs `missedCall`) for the same number are not suppressed

## Test plan
- [ ] `cargo test` — all 11 notification tests pass including new `call_notification_wrapper_works`
- [ ] `cargo clippy` — no warnings
- [ ] Receive a phone call and verify only one desktop notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)