### PR TITLE
Show group message sender names in conversation list, header, and notifications

### DIFF
--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -125,7 +125,7 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
             .iter()
             .take(params.conversations_displayed)
         {
-            let display_name = params.contacts.get_name_or_number(conv.primary_address());
+            let display_name = params.contacts.get_group_display_name(&conv.addresses, 3);
 
             let snippet = conv.last_message.chars().take(50).collect::<String>();
             let date_str = format_timestamp(conv.timestamp);
@@ -223,13 +223,10 @@ pub struct MessageThreadParams<'a> {
 
 /// Render the SMS message thread view.
 pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Message> {
-    let default_unknown = fl!("unknown");
-    let address = params
-        .thread_addresses
-        .and_then(|addrs| addrs.first())
-        .map(|s| s.as_str())
-        .unwrap_or(&default_unknown);
-    let display_name = params.contacts.get_name_or_number(address);
+    let display_name = match params.thread_addresses {
+        Some(addrs) => params.contacts.get_group_display_name(addrs, 3),
+        None => fl!("unknown"),
+    };
 
     // Build header with optional sync indicator
     let mut header_row = row![


### PR DESCRIPTION
## Summary

- Add `ContactLookup::get_group_display_name` to resolve multiple addresses into comma-separated contact names (e.g. "Alice, Bob, Charlie") for group SMS conversations
- Update conversation list, thread header, and SMS notifications to show group participant names instead of only the primary address
- Fix contact loading race condition where contacts were cleared and reloaded async every time the SMS view opened, causing names to briefly show as phone numbers
- Add dual D-Bus request pattern in conversation subscription: fire SMS plugin `request_all_conversations` (cache priming) before Conversations interface `request_all_conversation_threads` (local store signals)

## Test plan

- [ ] Open a group SMS conversation — conversation list row should show up to 3 participant names separated by commas
- [ ] Open the group thread — header should show the same group participant names
- [ ] Receive a group SMS notification — notification should show group names, not just primary address
- [ ] Verify per-message sender labels still show the individual sender name
- [ ] Verify contact names appear on first open (no race condition showing phone numbers)
- [ ] `cargo test -p kdeconnect-dbus` — unit tests for `get_group_display_name`
- [ ] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)