### PR TITLE
Optimize message loading with two-phase deadline-based subscription

### DIFF
--- a/cosmic-ext-connected/src/constants.rs
+++ b/cosmic-ext-connected/src/constants.rs
@@ -36,6 +36,16 @@ pub mod sms {
     /// Timeout for loading messages in a conversation thread (seconds).
     pub const MESSAGE_FETCH_TIMEOUT_SECS: u64 = 10;
 
+    /// Hard timeout for message loading subscription (seconds).
+    /// Safety net if conversationLoaded signal never arrives.
+    pub const MESSAGE_SUBSCRIPTION_TIMEOUT_SECS: u64 = 20;
+
+    /// Activity timeout after conversationLoaded for phone response data (milliseconds).
+    /// After the local store read completes (conversationLoaded signal), we keep listening
+    /// this long for additional messages from the phone. Resets on each D-Bus signal.
+    /// Needed because the local store may be empty/sparse after a reboot.
+    pub const PHONE_RESPONSE_TIMEOUT_MS: u64 = 8000;
+
     /// Interval for polling in fallback mode (milliseconds).
     pub const FALLBACK_POLLING_INTERVAL_MS: u64 = 500;
 


### PR DESCRIPTION
## Summary
- Replaces the simple signal-wait loop in the conversation message subscription with a two-phase deadline-based timeout strategy that correctly handles empty/sparse local stores after reboot
- Fixes the sync spinner staying active for the full 20s hard timeout by using a persistent `phone_deadline` in the state struct instead of a local `tokio::time::sleep` that was being reset by unrelated D-Bus traffic
- Fixes broken pagination after reboot by using a `messages.len() >= page_size` heuristic instead of the unreliable `total_count` from `conversationLoaded` (which reflects local store count, not phone total)

### How it works
1. **Phase 1** (before `conversationLoaded`): Wait for local store signals with no activity timeout — just the hard timeout safety net (20s)
2. **Phase 2** (after `conversationLoaded`): Start an 8s activity deadline that resets only when a *matching* message signal arrives for the current thread. Unrelated D-Bus signals no longer extend the timeout
3. `ConversationStoreLoaded` message provides an intermediate scroll-to-bottom when the local store read finishes, while the subscription continues listening for phone data
4. `Done` terminal state cleanly ends the subscription stream

## Test plan
- [ ] Open a conversation with many messages after a fresh reboot — messages should load progressively and the sync spinner should disappear within ~8s of the last message arriving (not 20s)
- [ ] Verify "Load More" button appears for conversations with more messages than the page size (default 10)
- [ ] Re-opening the same conversation should load messages from the now-populated local store
- [ ] Conversations with fewer messages should load quickly without unnecessary delay
- [ ] Verify no duplicate messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)