### PR TITLE
Fix configurable notification timeout on COSMIC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,12 @@ We fire both: SMS plugin first (cache priming), then Conversations interface (pe
 
 The `phone_deadline` must be stored in the `Listening` state struct (not a local variable) because each `unfold` yield exits and re-enters the function.
 
+### COSMIC's notification daemon ignores `expire_timeout`
+COSMIC's notification daemon does not respect the `expire_timeout` hint from the freedesktop notification spec. All notifications display for the daemon's fixed duration regardless of the value passed. To implement user-configurable notification duration, notifications must be created with `Timeout::Never` (expire_timeout=0) to prevent the daemon from auto-closing them, then explicitly closed via `NotificationHandle::close()` after the configured timeout. This is handled by `show_and_auto_close()` in `app.rs`.
+
+### Ping notifications cannot be intercepted via D-Bus
+KDE Connect's ping plugin (`kdeconnect_ping`) does not emit D-Bus signals for incoming pings. When a ping is received, `kdeconnectd` handles it internally and sends a desktop notification directly via `KNotification`, bypassing any D-Bus signal mechanism. The applet cannot detect or replace incoming ping notifications. The ping plugin only exposes `sendPing()` methods (outgoing), not incoming signals.
+
 ### `replyToConversation` is unreliable — use `sendWithoutConversation`
 `replyToConversation(threadId, message, attachments)` looks up addresses from `m_conversations[threadId]`. If the cache is empty, it **silently returns without sending** (no D-Bus error). Since `m_conversations` is only populated by phone-push responses through `addMessages()` (not by the Conversations interface's local-store reads), the cache is often empty.
 


### PR DESCRIPTION
## Summary
- COSMIC's notification daemon ignores the `expire_timeout` hint from the freedesktop notification spec, so the user-configurable notification timeout setting had no effect
- Notifications now use `Timeout::Never` (expire_timeout=0) to prevent the daemon from auto-closing them, then are explicitly closed via `NotificationHandle::close()` after the configured duration
- Extracted shared logic into a `show_and_auto_close()` helper used by all three notification types (SMS, call, file)

## Test plan
- [ ] Set notification timeout to a long value (e.g. 15-20s) in settings
- [ ] Trigger a file transfer from phone — notification should stay visible for the configured duration
- [ ] Trigger an SMS or call notification — same behavior
- [ ] Set timeout to a short value (e.g. 2s) — notification should dismiss quickly
- [ ] Manually dismiss a notification before timeout expires — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)