### PR TITLE
Adopt COSMIC design tokens and improve UI consistency

### DIFF
--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -4,7 +4,6 @@
 app-title = Connected
 
 # General UI
-back = Back
 settings = Settings
 loading = Loading...
 error = Error

--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -79,27 +79,23 @@ device-offline = Device is offline
 
 # Settings page
 settings-battery = Show battery percentage
-settings-battery-desc = Display battery level next to connected devices
 settings-offline = Show offline devices
-settings-offline-desc = Display paired devices that are not currently connected
 settings-notifications = Show notifications
-settings-notifications-desc = Display notifications from connected devices
+
+# Notification settings sub-page
+notification-settings = Notification settings
 
 # SMS Notifications settings
-settings-sms-notifications = SMS notifications
-settings-sms-notifications-desc = Show desktop notification when new SMS arrives
-settings-sms-show-content = Show message content
-settings-sms-show-content-desc = Display message preview in notification
-settings-sms-show-sender = Show sender name
-settings-sms-show-sender-desc = Display who sent the message
+settings-sms-section = SMS messages
+settings-sms-notifications = Show SMS messages
+settings-sms-show-sender = Show sender
+settings-sms-show-content = Show content
 
 # Call Notifications settings
-settings-call-notifications = Call notifications
-settings-call-notifications-desc = Show desktop notification for incoming and missed calls
-settings-call-show-number = Show phone number
-settings-call-show-number-desc = Display caller's phone number in notification
+settings-call-section = Calls
+settings-call-notifications = Show calls
 settings-call-show-name = Show caller name
-settings-call-show-name-desc = Display contact name if available
+settings-call-show-number = Show phone number
 
 # SMS Notification text
 sms-notification-title = New SMS
@@ -113,12 +109,11 @@ missed-call = Missed Call
 missed-call-from = Missed call from { $name }
 
 # File Notifications settings
-settings-file-notifications = File notifications
-settings-file-notifications-desc = Show notification when files are received
+settings-file-section = File transfers
+settings-file-notifications = Show file transfers
 
 # Notification timeout settings
-settings-notification-timeout = Notification duration
-settings-notification-timeout-desc = How long notifications stay on screen
+settings-notification-timeout = Duration
 notification-timeout-seconds = { $seconds }s
 
 # File Notification text

--- a/cosmic-ext-connected/src/media/views.rs
+++ b/cosmic-ext-connected/src/media/views.rs
@@ -211,20 +211,20 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
     .align_y(Alignment::Center)
     .padding([0, sp.space_xs as u16]);
 
+    let divider = || applet::padded_control(widget::divider::horizontal::default());
+
     // Assemble the view
     column![
         player_selector,
-        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
+        divider(),
         widget::container(widget::icon::from_name("multimedia-player-symbolic").size(48))
             .width(Length::Fill)
             .align_x(Alignment::Center),
-        widget::vertical_space().height(Length::Fixed(sp.space_xs as f32)),
         applet::padded_control(track_info),
-        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
+        divider(),
         position_display,
-        widget::vertical_space().height(Length::Fixed(sp.space_xs as f32)),
         controls_container,
-        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
+        divider(),
         volume_row,
     ]
     .spacing(sp.space_xxxs)

--- a/cosmic-ext-connected/src/media/views.rs
+++ b/cosmic-ext-connected/src/media/views.rs
@@ -3,9 +3,10 @@
 use crate::app::{MediaInfo, Message};
 use crate::fl;
 use crate::views::helpers::format_duration;
-use cosmic::iced::widget::{column, row, text};
+use cosmic::applet;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::widget;
+use cosmic::widget::{self, text};
 use cosmic::Element;
 
 /// Parameters for the media controls view.
@@ -17,28 +18,30 @@ pub struct MediaControlsParams<'a> {
 
 /// Render the media controls view.
 pub fn view_media_controls(params: MediaControlsParams<'_>) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
     let default_device = fl!("device");
     let device_name = params.device_name.unwrap_or(&default_device);
 
-    let header = row![
-        widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
-            .on_press(Message::CloseMediaView),
-        text(format!("{} - {}", fl!("media"), device_name)).size(16),
-        widget::horizontal_space(),
-    ]
-    .spacing(8)
-    .align_y(Alignment::Center)
-    .padding([8, 12]);
+    let header = applet::padded_control(
+        row![
+            widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
+                .on_press(Message::CloseMediaView),
+            text::heading(format!("{} - {}", fl!("media"), device_name)),
+            widget::horizontal_space(),
+        ]
+        .spacing(sp.space_xxs)
+        .align_y(Alignment::Center),
+    );
 
     let content: Element<Message> = if params.media_loading {
         widget::container(
-            column![text(fl!("loading-media")).size(14),]
-                .spacing(12)
+            column![text::body(fl!("loading-media")),]
+                .spacing(sp.space_xs)
                 .align_x(Alignment::Center),
         )
         .width(Length::Fill)
         .align_x(Alignment::Center)
-        .padding(24)
+        .padding(sp.space_m)
         .into()
     } else if let Some(info) = params.media_info {
         if info.players.is_empty() {
@@ -46,15 +49,15 @@ pub fn view_media_controls(params: MediaControlsParams<'_>) -> Element<'_, Messa
             widget::container(
                 column![
                     widget::icon::from_name("multimedia-player-symbolic").size(48),
-                    text(fl!("no-media-players")).size(14),
-                    text(fl!("start-playing")).size(12),
+                    text::body(fl!("no-media-players")),
+                    text::caption(fl!("start-playing")),
                 ]
-                .spacing(12)
+                .spacing(sp.space_xs)
                 .align_x(Alignment::Center),
             )
             .width(Length::Fill)
             .align_x(Alignment::Center)
-            .padding(24)
+            .padding(sp.space_m)
             .into()
         } else {
             // Show media controls
@@ -65,26 +68,28 @@ pub fn view_media_controls(params: MediaControlsParams<'_>) -> Element<'_, Messa
         widget::container(
             column![
                 widget::icon::from_name("dialog-error-symbolic").size(48),
-                text(fl!("media-not-available")).size(14),
-                text(fl!("enable-mpris")).size(12),
+                text::body(fl!("media-not-available")),
+                text::caption(fl!("enable-mpris")),
             ]
-            .spacing(12)
+            .spacing(sp.space_xs)
             .align_x(Alignment::Center),
         )
         .width(Length::Fill)
         .align_x(Alignment::Center)
-        .padding(24)
+        .padding(sp.space_m)
         .into()
     };
 
-    column![header, widget::divider::horizontal::default(), content,]
-        .spacing(8)
+    column![header, content,]
+        .spacing(sp.space_xxs)
         .width(Length::Fill)
         .into()
 }
 
 /// Render the media player with controls.
 pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
+
     // Player selector (if multiple players)
     let player_selector: Element<Message> = if info.players.len() > 1 {
         let players: Vec<String> = info.players.clone();
@@ -99,23 +104,20 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
         };
         let players_for_dropdown: Vec<String> = players.clone();
 
-        widget::container(
+        applet::padded_control(
             row![
-                text(fl!("player")).size(12),
+                text::caption(fl!("player")),
                 widget::dropdown(players, selected_idx, move |idx| {
                     Message::MediaSelectPlayer(players_for_dropdown[idx].clone())
                 })
                 .width(Length::Fill),
             ]
-            .spacing(8)
+            .spacing(sp.space_xxs)
             .align_y(Alignment::Center),
         )
-        .padding([0, 12])
         .into()
     } else {
-        widget::container(text(info.current_player.clone()).size(12))
-            .padding([0, 12])
-            .into()
+        applet::padded_control(text::caption(info.current_player.clone())).into()
     };
 
     // Track info
@@ -136,11 +138,11 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
     };
 
     let track_info = column![
-        text(title_text).size(16),
-        text(artist_text).size(13),
-        text(album_text).size(11),
+        text::body(title_text),
+        text::caption(artist_text),
+        text::caption(album_text),
     ]
-    .spacing(4)
+    .spacing(sp.space_xxxs)
     .align_x(Alignment::Center)
     .width(Length::Fill);
 
@@ -148,11 +150,11 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
     let position_str = format_duration(info.position);
     let length_str = format_duration(info.length);
     let position_display = row![
-        text(position_str).size(10),
+        text::caption(position_str),
         widget::horizontal_space(),
-        text(length_str).size(10),
+        text::caption(length_str),
     ]
-    .padding([0, 12]);
+    .padding([0, sp.space_xs as u16]);
 
     // Playback controls
     let play_icon = if info.is_playing {
@@ -179,7 +181,7 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
         });
 
     let playback_controls = row![prev_button, play_button, next_button,]
-        .spacing(16)
+        .spacing(sp.space_s)
         .align_y(Alignment::Center);
 
     let controls_container = widget::container(playback_controls)
@@ -202,32 +204,31 @@ pub fn view_media_player(info: &MediaInfo) -> Element<'_, Message> {
     let volume_row = row![
         widget::icon::from_name(volume_icon).size(20),
         volume_slider,
-        text(format!("{}%", info.volume))
-            .size(10)
+        text::caption(format!("{}%", info.volume))
             .width(Length::Fixed(36.0)),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .align_y(Alignment::Center)
-    .padding([0, 12]);
+    .padding([0, sp.space_xs as u16]);
 
     // Assemble the view
     column![
         player_selector,
-        widget::vertical_space().height(Length::Fixed(16.0)),
+        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
         widget::container(widget::icon::from_name("multimedia-player-symbolic").size(48))
             .width(Length::Fill)
             .align_x(Alignment::Center),
-        widget::vertical_space().height(Length::Fixed(12.0)),
-        widget::container(track_info).padding([0, 12]),
-        widget::vertical_space().height(Length::Fixed(16.0)),
+        widget::vertical_space().height(Length::Fixed(sp.space_xs as f32)),
+        applet::padded_control(track_info),
+        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
         position_display,
-        widget::vertical_space().height(Length::Fixed(12.0)),
+        widget::vertical_space().height(Length::Fixed(sp.space_xs as f32)),
         controls_container,
-        widget::vertical_space().height(Length::Fixed(16.0)),
+        widget::vertical_space().height(Length::Fixed(sp.space_s as f32)),
         volume_row,
     ]
-    .spacing(4)
-    .padding([0, 0, 16, 0]) // Add bottom padding
+    .spacing(sp.space_xxxs)
+    .padding([0, 0, sp.space_s as u16, 0])
     .width(Length::Fill)
     .into()
 }

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -3,9 +3,10 @@
 use crate::app::{LoadingPhase, Message, SmsLoadingState};
 use crate::fl;
 use crate::views::helpers::{format_timestamp, WIDE_POPUP_WIDTH};
-use cosmic::iced::widget::{column, row, text};
+use cosmic::applet;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::widget;
+use cosmic::widget::{self, text};
 use cosmic::Element;
 use kdeconnect_dbus::contacts::ContactLookup;
 use kdeconnect_dbus::plugins::{is_address_valid, ConversationSummary, MessageType, SmsMessage};
@@ -64,6 +65,7 @@ pub struct ConversationListParams<'a> {
 
 /// Render the SMS conversation list view.
 pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
     let default_device = fl!("device");
     let device_name = params.device_name.unwrap_or(&default_device);
 
@@ -71,9 +73,9 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
     let mut header_row = row![
         widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
             .on_press(Message::CloseSmsView),
-        text(fl!("messages-title", device = device_name)).size(16),
+        text::heading(fl!("messages-title", device = device_name)),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .align_y(Alignment::Center);
 
     // Show sync indicator when background sync is active
@@ -81,26 +83,27 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
         header_row = header_row.push(
             widget::tooltip(
                 widget::icon::from_name("emblem-synchronizing-symbolic").size(16),
-                text(fl!("syncing")).size(12),
+                text::caption(fl!("syncing")),
                 widget::tooltip::Position::Bottom,
             )
-            .padding(4),
+            .padding(sp.space_xxxs),
         );
     }
 
-    let header = header_row
-        .push(widget::horizontal_space())
-        .push(
-            widget::button::icon(widget::icon::from_name("list-add-symbolic"))
-                .on_press(Message::OpenNewMessage),
-        )
-        .padding([8, 12]);
+    let header = applet::padded_control(
+        header_row
+            .push(widget::horizontal_space())
+            .push(
+                widget::button::icon(widget::icon::from_name("list-add-symbolic"))
+                    .on_press(Message::OpenNewMessage),
+            ),
+    );
 
     let content: Element<Message> = if is_loading_conversations(params.loading_state)
         && params.conversations.is_empty()
     {
         widget::container(
-            column![text(conversation_loading_text(params.loading_state)).size(14),]
+            column![text::body(conversation_loading_text(params.loading_state)),]
                 .align_x(Alignment::Center),
         )
         .center(Length::Fill)
@@ -109,17 +112,17 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
         widget::container(
             column![
                 widget::icon::from_name("mail-message-new-symbolic").size(48),
-                text(fl!("no-conversations")).size(16),
-                text(fl!("start-new-message")).size(12),
+                text::heading(fl!("no-conversations")),
+                text::caption(fl!("start-new-message")),
             ]
-            .spacing(12)
+            .spacing(sp.space_xs)
             .align_x(Alignment::Center),
         )
         .center(Length::Fill)
         .into()
     } else {
         // Build conversation list (limited to conversations_displayed)
-        let mut conv_column = column![].spacing(4);
+        let mut conv_column = column![].spacing(sp.space_xxxs);
         for conv in params
             .conversations
             .iter()
@@ -130,23 +133,17 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
             let snippet = conv.last_message.chars().take(50).collect::<String>();
             let date_str = format_timestamp(conv.timestamp);
 
-            let conv_row = widget::button::custom(
-                widget::container(
-                    row![
-                        column![text(display_name).size(14), text(snippet).size(11),].spacing(2),
-                        widget::horizontal_space(),
-                        text(date_str).size(10),
-                        widget::icon::from_name("go-next-symbolic").size(16),
-                    ]
-                    .spacing(8)
-                    .align_y(Alignment::Center),
-                )
-                .padding(8)
-                .width(Length::Fill),
+            let conv_row = applet::menu_button(
+                row![
+                    column![text::body(display_name), text::caption(snippet),].spacing(2),
+                    widget::horizontal_space(),
+                    text::caption(date_str),
+                    widget::icon::from_name("go-next-symbolic").size(16),
+                ]
+                .spacing(sp.space_xxs)
+                .align_y(Alignment::Center),
             )
-            .class(cosmic::theme::Button::Text)
-            .on_press(Message::OpenConversation(conv.thread_id))
-            .width(Length::Fill);
+            .on_press(Message::OpenConversation(conv.thread_id));
 
             conv_column = conv_column.push(conv_row);
         }
@@ -155,50 +152,43 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
         if params.conversations_displayed < params.conversations.len() {
             let load_more_row = row![
                 widget::icon::from_name("go-down-symbolic").size(16),
-                text(fl!("load-more-conversations")).size(14),
+                text::body(fl!("load-more-conversations")),
             ]
-            .spacing(8)
+            .spacing(sp.space_xxs)
             .align_y(Alignment::Center);
 
-            let load_more_button = widget::button::custom(
+            let load_more_button = applet::menu_button(
                 widget::container(load_more_row)
-                    .padding(8)
                     .width(Length::Fill)
                     .align_x(Alignment::Center),
             )
-            .class(cosmic::theme::Button::Text)
-            .on_press(Message::LoadMoreConversations)
-            .width(Length::Fill);
+            .on_press(Message::LoadMoreConversations);
 
-            conv_column = conv_column.push(widget::divider::horizontal::default());
             conv_column = conv_column.push(load_more_button);
         }
 
         // Show sync progress indicator at bottom when still syncing
         if params.sync_active {
-            conv_column = conv_column.push(widget::divider::horizontal::default());
             conv_column = conv_column.push(
-                widget::container(
+                applet::padded_control(
                     row![
                         widget::icon::from_name("emblem-synchronizing-symbolic").size(16),
-                        text(fl!("syncing-conversations")).size(12),
+                        text::caption(fl!("syncing-conversations")),
                     ]
-                    .spacing(8)
+                    .spacing(sp.space_xxs)
                     .align_y(Alignment::Center),
                 )
-                .padding(12)
-                .width(Length::Fill)
                 .align_x(Alignment::Center),
             );
         }
 
-        widget::scrollable(conv_column.padding([0, 8]))
+        widget::scrollable(conv_column.padding([0, sp.space_xxs as u16]))
             .width(Length::Fill)
             .into()
     };
 
-    column![header, widget::divider::horizontal::default(), content,]
-        .spacing(8)
+    column![header, content,]
+        .spacing(sp.space_xxs)
         .width(Length::Fill)
         .into()
 }
@@ -223,6 +213,7 @@ pub struct MessageThreadParams<'a> {
 
 /// Render the SMS message thread view.
 pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
     let display_name = match params.thread_addresses {
         Some(addrs) => params.contacts.get_group_display_name(addrs, 3),
         None => fl!("unknown"),
@@ -232,9 +223,9 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
     let mut header_row = row![
         widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
             .on_press(Message::CloseConversation),
-        text(display_name).size(16),
+        text::heading(display_name),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .align_y(Alignment::Center);
 
     // Show sync indicator when background sync is active
@@ -242,16 +233,16 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
         header_row = header_row.push(
             widget::tooltip(
                 widget::icon::from_name("emblem-synchronizing-symbolic").size(16),
-                text(fl!("syncing")).size(12),
+                text::caption(fl!("syncing")),
                 widget::tooltip::Position::Bottom,
             )
-            .padding(4),
+            .padding(sp.space_xxxs),
         );
     }
 
-    let header = header_row
-        .push(widget::horizontal_space())
-        .padding([8, 12]);
+    let header = applet::padded_control(
+        header_row.push(widget::horizontal_space()),
+    );
 
     // Show loading indicator only when loading AND no messages yet
     // Once messages start arriving, show them (scrolled to bottom)
@@ -259,13 +250,13 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
         && params.messages.is_empty()
     {
         widget::container(
-            column![text(message_loading_text(params.loading_state)).size(14),]
+            column![text::body(message_loading_text(params.loading_state)),]
                 .align_x(Alignment::Center),
         )
         .center(Length::Fill)
         .into()
     } else if params.messages.is_empty() {
-        widget::container(column![text(fl!("no-messages")).size(14),].align_x(Alignment::Center))
+        widget::container(column![text::body(fl!("no-messages")),].align_x(Alignment::Center))
             .center(Length::Fill)
             .into()
     } else {
@@ -274,25 +265,24 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
         let bubble_max_width = (WIDE_POPUP_WIDTH * 0.75) as u16;
         let loading_more = is_loading_more(params.loading_state);
 
-        let mut msg_column = column![].spacing(12).padding([8, 12]);
+        let mut msg_column = column![].spacing(sp.space_xs).padding([sp.space_xxs, sp.space_xs]);
 
         // Show loading indicator at top when fetching older messages
         if loading_more {
             let loading_indicator: Element<Message> = widget::container(
                 row![
                     widget::icon::from_name("process-working-symbolic").size(16),
-                    text(fl!("loading-older")).size(14),
+                    text::body(fl!("loading-older")),
                 ]
-                .spacing(8)
+                .spacing(sp.space_xxs)
                 .align_y(Alignment::Center),
             )
-            .padding(8)
+            .padding(sp.space_xxs)
             .width(Length::Fill)
             .align_x(Alignment::Center)
             .into();
 
             msg_column = msg_column.push(loading_indicator);
-            msg_column = msg_column.push(widget::divider::horizontal::default());
         }
 
         for msg in params.messages {
@@ -304,23 +294,26 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
 
             // Message bubble content (long-press to copy)
             let bubble_content =
-                column![text(&msg.body).size(13).wrapping(text::Wrapping::Word), text(time_str).size(9),]
-                    .spacing(4);
+                column![
+                    text::body(&msg.body).wrapping(cosmic::iced::widget::text::Wrapping::Word),
+                    text::caption(time_str),
+                ]
+                .spacing(sp.space_xxxs);
 
             // Use highlighted style when pressed for high contrast visual feedback
             let bubble: Element<Message> = if is_pressed {
                 // Wrap in two containers for a "selected" border effect
                 let inner = widget::container(bubble_content)
-                    .padding([8, 12])
+                    .padding([sp.space_xxs, sp.space_xs])
                     .max_width(bubble_max_width - 8)
                     .class(cosmic::theme::Container::Primary);
                 widget::container(inner)
-                    .padding(4)
+                    .padding(sp.space_xxxs)
                     .class(cosmic::theme::Container::Dropdown)
                     .into()
             } else {
                 widget::container(bubble_content)
-                    .padding([8, 12])
+                    .padding([sp.space_xxs, sp.space_xs])
                     .max_width(bubble_max_width)
                     .class(if is_received {
                         cosmic::theme::Container::Card
@@ -342,7 +335,7 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
             let bubble_element: Element<Message> = if show_hint {
                 column![
                     bubble_with_press,
-                    text(fl!("hold-to-copy")).size(10),
+                    text::caption(fl!("hold-to-copy")),
                 ]
                 .spacing(2)
                 .into()
@@ -363,10 +356,10 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
                     let sender_name =
                         params.contacts.get_name_or_number(msg.primary_address());
                     column![
-                        text(sender_name).size(11),
+                        text::caption(sender_name),
                         row![bubble_element, widget::horizontal_space(),].width(Length::Fill),
                     ]
-                    .spacing(4)
+                    .spacing(sp.space_xxxs)
                     .width(Length::Fill)
                     .into()
                 } else {
@@ -413,27 +406,24 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
             .into()
     };
 
-    let compose_row = widget::container(
+    let compose_row = applet::padded_control(
         row![compose_input, send_btn,]
-            .spacing(8)
+            .spacing(sp.space_xxs)
             .align_y(Alignment::Center),
-    )
-    .padding([8, 12]);
+    );
 
     let mut thread_column = column![
         header,
-        widget::divider::horizontal::default(),
         content,
-        widget::divider::horizontal::default(),
         compose_row,
     ]
-    .spacing(4)
+    .spacing(sp.space_xxxs)
     .width(Length::Fill);
 
     if let Some(msg) = params.status_message {
         thread_column = thread_column.push(
-            widget::container(text(msg).size(11).wrapping(text::Wrapping::Word))
-                .padding([4, 12])
+            widget::container(text::caption(msg).wrapping(cosmic::iced::widget::text::Wrapping::Word))
+                .padding([sp.space_xxxs, sp.space_xs])
                 .width(Length::Fill)
                 .class(cosmic::theme::Container::Card),
         );
@@ -454,15 +444,18 @@ pub struct NewMessageParams<'a> {
 
 /// Render the new message compose view.
 pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
-    let header = row![
-        widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
-            .on_press(Message::CloseNewMessage),
-        text(fl!("new-message")).size(16),
-        widget::horizontal_space(),
-    ]
-    .spacing(8)
-    .align_y(Alignment::Center)
-    .padding([8, 12]);
+    let sp = cosmic::theme::spacing();
+
+    let header = applet::padded_control(
+        row![
+            widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
+                .on_press(Message::CloseNewMessage),
+            text::heading(fl!("new-message")),
+            widget::horizontal_space(),
+        ]
+        .spacing(sp.space_xxs)
+        .align_y(Alignment::Center),
+    );
 
     // Recipient input with validation indicator
     let recipient_input = widget::text_input(fl!("recipient-placeholder"), params.recipient)
@@ -482,12 +475,11 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
             .into()
     };
 
-    let recipient_row = widget::container(
-        row![text(fl!("to")).size(14), recipient_input, validation_icon,]
-            .spacing(8)
+    let recipient_row = applet::padded_control(
+        row![text::body(fl!("to")), recipient_input, validation_icon,]
+            .spacing(sp.space_xxs)
             .align_y(Alignment::Center),
-    )
-    .padding([8, 12]);
+    );
 
     // Contact suggestions (show if recipient is being typed and we have matches)
     // Each suggestion is a (contact_name, phone_number) tuple, sorted by conversation recency
@@ -495,28 +487,22 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
         && !is_address_valid(params.recipient)
         && !params.contact_suggestions.is_empty()
     {
-        let mut suggestions_col = column![].spacing(4);
+        let mut suggestions_col = column![].spacing(sp.space_xxxs);
         for (name, phone) in params.contact_suggestions.iter() {
-            let contact_row = widget::button::custom(
-                widget::container(
-                    row![
-                        widget::icon::from_name("contact-new-symbolic").size(20),
-                        column![text(name.clone()).size(13), text(phone.clone()).size(11),]
-                            .spacing(2),
-                    ]
-                    .spacing(8)
-                    .align_y(Alignment::Center),
-                )
-                .padding(8)
-                .width(Length::Fill),
+            let contact_row = applet::menu_button(
+                row![
+                    widget::icon::from_name("contact-new-symbolic").size(20),
+                    column![text::body(name.clone()), text::caption(phone.clone()),]
+                        .spacing(2),
+                ]
+                .spacing(sp.space_xxs)
+                .align_y(Alignment::Center),
             )
-            .class(cosmic::theme::Button::Text)
-            .on_press(Message::SelectContact(name.clone(), phone.clone()))
-            .width(Length::Fill);
+            .on_press(Message::SelectContact(name.clone(), phone.clone()));
             suggestions_col = suggestions_col.push(contact_row);
         }
         widget::container(suggestions_col)
-            .padding([0, 12])
+            .padding([0, sp.space_xs as u16])
             .width(Length::Fill)
             .into()
     } else {
@@ -543,23 +529,21 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
             })
     };
 
-    let send_row = widget::container(
+    let send_row = applet::padded_control(
         row![widget::horizontal_space(), send_btn,]
-            .spacing(8)
+            .spacing(sp.space_xxs)
             .align_y(Alignment::Center),
-    )
-    .padding([8, 12]);
+    );
 
     column![
         header,
-        widget::divider::horizontal::default(),
         recipient_row,
         suggestions_section,
-        widget::container(message_input).padding([8, 12]),
+        applet::padded_control(message_input),
         send_row,
         widget::vertical_space(),
     ]
-    .spacing(4)
+    .spacing(sp.space_xxxs)
     .width(Length::Fill)
     .into()
 }

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -90,13 +90,19 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
         );
     }
 
+    let new_msg_btn = widget::tooltip(
+        widget::button::icon(widget::icon::from_name("list-add-symbolic"))
+            .on_press(Message::OpenNewMessage),
+        text::caption(fl!("new-message")),
+        widget::tooltip::Position::Bottom,
+    )
+    .gap(sp.space_xxxs)
+    .padding(sp.space_xxs);
+
     let header = applet::padded_control(
         header_row
             .push(widget::horizontal_space())
-            .push(
-                widget::button::icon(widget::icon::from_name("list-add-symbolic"))
-                    .on_press(Message::OpenNewMessage),
-            ),
+            .push(new_msg_btn),
     );
 
     let content: Element<Message> = if is_loading_conversations(params.loading_state)

--- a/cosmic-ext-connected/src/ui/device_page.rs
+++ b/cosmic-ext-connected/src/ui/device_page.rs
@@ -16,8 +16,7 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
     let sp = cosmic::theme::spacing();
 
     // Back button
-    let back_btn = widget::button::text(fl!("back"))
-        .leading_icon(icon::from_name("go-previous-symbolic").size(16))
+    let back_btn = widget::button::icon(icon::from_name("go-previous-symbolic"))
         .on_press(Message::BackToList);
 
     // Device icon based on type
@@ -32,6 +31,7 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
     // Build header row with device info and optional ping button
     let header: Element<Message> = {
         let mut header_row = row![
+            back_btn,
             icon::from_name(icon_name).size(48),
             column![
                 text::title4(device.name.clone()),
@@ -60,7 +60,7 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
             header_row = header_row.push(ping_with_tooltip);
         }
 
-        header_row.into()
+        applet::padded_control(header_row).into()
     };
 
     // Build the combined status row with connected, paired, and battery
@@ -155,20 +155,20 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
         widget::Space::new(Length::Shrink, Length::Shrink).into()
     };
 
-    widget::container(
-        column![
-            back_btn,
-            status_bar,
-            header,
-            status_row,
-            actions,
-            pairing_section,
-            notifications_section,
-        ]
-        .spacing(sp.space_xs)
-        .padding(sp.space_s),
-    )
-    .into()
+    let divider = || applet::padded_control(widget::divider::horizontal::default());
+
+    let mut content = column![header, status_bar, status_row, divider(), actions,]
+        .spacing(sp.space_xs);
+
+    content = content.push(divider());
+    content = content.push(pairing_section);
+
+    if !device.notifications.is_empty() {
+        content = content.push(divider());
+        content = content.push(notifications_section);
+    }
+
+    widget::container(content).into()
 }
 
 /// Build the combined status row showing connected, paired, and battery status.

--- a/cosmic-ext-connected/src/ui/device_page.rs
+++ b/cosmic-ext-connected/src/ui/device_page.rs
@@ -4,14 +4,17 @@
 
 use crate::app::{DeviceInfo, Message};
 use crate::fl;
-use cosmic::iced::widget::{column, row, text, tooltip};
+use cosmic::applet;
+use cosmic::iced::widget::{column, row, tooltip};
 use cosmic::iced::{Alignment, Length};
-use cosmic::widget::{self, icon};
+use cosmic::widget::{self, icon, text};
 use cosmic::Element;
 use kdeconnect_dbus::plugins::NotificationInfo;
 
 /// Render the device detail page.
 pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Element<'a, Message> {
+    let sp = cosmic::theme::spacing();
+
     // Back button
     let back_btn = widget::button::text(fl!("back"))
         .leading_icon(icon::from_name("go-previous-symbolic").size(16))
@@ -31,13 +34,13 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
         let mut header_row = row![
             icon::from_name(icon_name).size(48),
             column![
-                text(device.name.clone()).size(18),
-                text(device.device_type.clone()).size(12),
+                text::title4(device.name.clone()),
+                text::caption(device.device_type.clone()),
             ]
-            .spacing(4),
+            .spacing(sp.space_xxxs),
             widget::horizontal_space(),
         ]
-        .spacing(16)
+        .spacing(sp.space_s)
         .align_y(Alignment::Center);
 
         // Add ping button if device is reachable and paired
@@ -46,14 +49,14 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
             let ping_btn =
                 widget::button::icon(icon::from_name("emblem-synchronizing-symbolic").size(20))
                     .on_press(Message::SendPing(device_id_for_ping))
-                    .padding(8);
+                    .padding(sp.space_xxs);
             let ping_with_tooltip = tooltip(
                 ping_btn,
-                text(fl!("send-ping")).size(11),
+                text::caption(fl!("send-ping")),
                 tooltip::Position::Bottom,
             )
-            .gap(4)
-            .padding(8);
+            .gap(sp.space_xxxs)
+            .padding(sp.space_xxs);
             header_row = header_row.push(ping_with_tooltip);
         }
 
@@ -74,77 +77,65 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
         // SMS Messages action item
         let sms_row = row![
             icon::from_name("mail-message-new-symbolic").size(24),
-            text(fl!("sms-messages")).size(14),
+            text::body(fl!("sms-messages")),
             widget::horizontal_space(),
             icon::from_name("go-next-symbolic").size(16),
         ]
-        .spacing(12)
+        .spacing(sp.space_xs)
         .align_y(Alignment::Center);
 
-        let sms_item =
-            widget::button::custom(widget::container(sms_row).padding(8).width(Length::Fill))
-                .class(cosmic::theme::Button::Text)
-                .on_press(Message::OpenSmsView(device_id_for_sms))
-                .width(Length::Fill);
+        let sms_item = applet::menu_button(sms_row)
+            .on_press(Message::OpenSmsView(device_id_for_sms));
 
         // Send to device action item
         let sendto_row = row![
             icon::from_name("document-send-symbolic").size(24),
-            text(fl!("send-to", device = device.device_type.as_str())).size(14),
+            text::body(fl!("send-to", device = device.device_type.as_str())),
             widget::horizontal_space(),
             icon::from_name("go-next-symbolic").size(16),
         ]
-        .spacing(12)
+        .spacing(sp.space_xs)
         .align_y(Alignment::Center);
 
-        let sendto_item =
-            widget::button::custom(widget::container(sendto_row).padding(8).width(Length::Fill))
-                .class(cosmic::theme::Button::Text)
-                .on_press(Message::OpenSendToView(
-                    device_id_for_sendto,
-                    device_type_for_sendto,
-                ))
-                .width(Length::Fill);
+        let sendto_item = applet::menu_button(sendto_row)
+            .on_press(Message::OpenSendToView(
+                device_id_for_sendto,
+                device_type_for_sendto,
+            ));
 
         // Media controls action item
         let media_row = row![
             icon::from_name("multimedia-player-symbolic").size(24),
-            text(fl!("media-controls")).size(14),
+            text::body(fl!("media-controls")),
             widget::horizontal_space(),
             icon::from_name("go-next-symbolic").size(16),
         ]
-        .spacing(12)
+        .spacing(sp.space_xs)
         .align_y(Alignment::Center);
 
-        let media_item =
-            widget::button::custom(widget::container(media_row).padding(8).width(Length::Fill))
-                .class(cosmic::theme::Button::Text)
-                .on_press(Message::OpenMediaView(device_id_for_media))
-                .width(Length::Fill);
+        let media_item = applet::menu_button(media_row)
+            .on_press(Message::OpenMediaView(device_id_for_media));
 
         // Find Phone action item (no chevron - immediate action)
         let find_row = row![
             icon::from_name("audio-volume-high-symbolic").size(24),
-            text(fl!("find-phone")).size(14),
+            text::body(fl!("find-phone")),
             widget::horizontal_space(),
         ]
-        .spacing(12)
+        .spacing(sp.space_xs)
         .align_y(Alignment::Center);
 
-        let find_item =
-            widget::button::custom(widget::container(find_row).padding(8).width(Length::Fill))
-                .class(cosmic::theme::Button::Text)
-                .on_press(Message::FindMyPhone(device_id_for_find))
-                .width(Length::Fill);
+        let find_item = applet::menu_button(find_row)
+            .on_press(Message::FindMyPhone(device_id_for_find));
 
         column![sms_item, sendto_item, media_item, find_item,]
-            .spacing(4)
+            .spacing(sp.space_xxxs)
             .into()
     } else if !device.is_paired {
         // Not paired - show nothing (pairing section will be shown below)
         widget::Space::new(Length::Shrink, Length::Shrink).into()
     } else {
-        text(fl!("device-must-be-connected")).size(12).into()
+        text::caption(fl!("device-must-be-connected")).into()
     };
 
     // Pairing section
@@ -155,8 +146,8 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
 
     // Build status message element if present
     let status_bar: Element<Message> = if let Some(msg) = status_message {
-        widget::container(text(msg).size(11))
-            .padding([4, 8])
+        widget::container(text::caption(msg))
+            .padding([sp.space_xxxs, sp.space_xxs])
             .width(Length::Fill)
             .class(cosmic::theme::Container::Card)
             .into()
@@ -168,22 +159,22 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
         column![
             back_btn,
             status_bar,
-            widget::divider::horizontal::default(),
             header,
             status_row,
-            widget::divider::horizontal::default(),
             actions,
             pairing_section,
             notifications_section,
         ]
-        .spacing(12)
-        .padding(16),
+        .spacing(sp.space_xs)
+        .padding(sp.space_s),
     )
     .into()
 }
 
 /// Build the combined status row showing connected, paired, and battery status.
 fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
+    let sp = cosmic::theme::spacing();
+
     // Connected status (left-aligned) - use icon to indicate status
     let connected_icon_name = if device.is_reachable {
         "emblem-ok-symbolic" // Green checkmark
@@ -192,9 +183,9 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
     };
     let connected_element = row![
         icon::from_name(connected_icon_name).size(16),
-        text(fl!("connected")).size(12),
+        text::caption(fl!("connected")),
     ]
-    .spacing(4)
+    .spacing(sp.space_xxxs)
     .align_y(Alignment::Center);
 
     // Paired status (center-aligned) - use icon to indicate status
@@ -205,9 +196,9 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
     };
     let paired_element = row![
         icon::from_name(paired_icon_name).size(16),
-        text(fl!("paired")).size(12),
+        text::caption(fl!("paired")),
     ]
-    .spacing(4)
+    .spacing(sp.space_xxxs)
     .align_y(Alignment::Center);
 
     // Battery status (right-aligned) - percentage text + icon
@@ -215,12 +206,12 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
     let battery_element: Element<Message> =
         if let (Some(level), Some(charging)) = (device.battery_level, device.battery_charging) {
             if level >= 0 {
-                let icon_name = get_battery_icon_name(level, charging);
+                let battery_icon_name = get_battery_icon_name(level, charging);
                 row![
-                    text(format!("{}%", level)).size(12),
-                    icon::from_name(icon_name).size(24),
+                    text::caption(format!("{}%", level)),
+                    icon::from_name(battery_icon_name).size(24),
                 ]
-                .spacing(4)
+                .spacing(sp.space_xxxs)
                 .align_y(Alignment::Center)
                 .into()
             } else {
@@ -276,6 +267,7 @@ fn get_battery_icon_name(level: i32, charging: bool) -> &'static str {
 
 /// Build the pairing section based on device state.
 fn build_pairing_section<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
+    let sp = cosmic::theme::spacing();
     let device_id = device.id.clone();
 
     // If peer requested pairing, show accept/reject buttons
@@ -283,8 +275,8 @@ fn build_pairing_section<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
         let accept_id = device_id.clone();
         let reject_id = device_id;
         return column![
-            text(fl!("pairing-request")).size(14),
-            text(fl!("device-wants-to-pair")).size(12),
+            text::heading(fl!("pairing-request")),
+            text::caption(fl!("device-wants-to-pair")),
             row![
                 widget::button::suggested(fl!("accept"))
                     .leading_icon(icon::from_name("emblem-ok-symbolic").size(16))
@@ -293,79 +285,78 @@ fn build_pairing_section<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
                     .leading_icon(icon::from_name("window-close-symbolic").size(16))
                     .on_press(Message::RejectPairing(reject_id)),
             ]
-            .spacing(8),
+            .spacing(sp.space_xxs),
         ]
-        .spacing(8)
+        .spacing(sp.space_xxs)
         .into();
     }
 
     // If we requested pairing, show cancel button
     if device.is_pair_requested {
         return column![
-            text(fl!("pairing")).size(14),
-            text(fl!("waiting-for-device")).size(12),
+            text::heading(fl!("pairing")),
+            text::caption(fl!("waiting-for-device")),
             widget::button::standard(fl!("cancel")).on_press(Message::RejectPairing(device_id)),
         ]
-        .spacing(8)
+        .spacing(sp.space_xxs)
         .into();
     }
 
     // If paired, show unpair button
     if device.is_paired {
         return column![
-            text(fl!("pairing")).size(14),
+            text::heading(fl!("pairing")),
             widget::button::destructive(fl!("unpair"))
                 .leading_icon(icon::from_name("list-remove-symbolic").size(16))
                 .on_press(Message::Unpair(device_id)),
         ]
-        .spacing(8)
+        .spacing(sp.space_xxs)
         .into();
     }
 
     // If reachable but not paired, show pair button
     if device.is_reachable {
         return column![
-            text(fl!("pairing")).size(14),
-            text(fl!("device-not-paired")).size(12),
+            text::heading(fl!("pairing")),
+            text::caption(fl!("device-not-paired")),
             widget::button::suggested(fl!("pair"))
                 .leading_icon(icon::from_name("list-add-symbolic").size(16))
                 .on_press(Message::RequestPair(device_id)),
         ]
-        .spacing(8)
+        .spacing(sp.space_xxs)
         .into();
     }
 
     // Offline and not paired
     column![
-        text(fl!("pairing")).size(14),
-        text(fl!("device-offline")).size(12),
+        text::heading(fl!("pairing")),
+        text::caption(fl!("device-offline")),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .into()
 }
 
 /// Build the notifications section.
 fn build_notifications_section<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
+    let sp = cosmic::theme::spacing();
+
     if device.notifications.is_empty() {
         return widget::Space::new(Length::Shrink, Length::Shrink).into();
     }
 
-    let mut notif_column = column![text(format!(
+    let mut notif_column = column![text::heading(format!(
         "{} ({})",
         fl!("notifications"),
         device.notifications.len()
-    ))
-    .size(14),]
-    .spacing(8);
+    )),]
+    .spacing(sp.space_xxs);
 
     for notif in &device.notifications {
         let notif_widget = build_notification_row(device, notif);
         notif_column = notif_column.push(notif_widget);
     }
 
-    notif_column
-        .push(widget::divider::horizontal::default())
-        .into()
+    notif_column.into()
 }
 
 /// Build a single notification row.
@@ -373,20 +364,22 @@ fn build_notification_row<'a>(
     device: &'a DeviceInfo,
     notif: &'a NotificationInfo,
 ) -> Element<'a, Message> {
+    let sp = cosmic::theme::spacing();
+
     let notif_title = if notif.title.is_empty() {
         notif.app_name.clone()
     } else {
         format!("{}: {}", notif.app_name, notif.title)
     };
 
-    let notif_content = column![text(notif_title).size(13), text(&notif.text).size(11),].spacing(2);
+    let notif_content = column![text::body(notif_title), text::caption(&notif.text),].spacing(2);
 
     let mut notif_row = row![
         icon::from_name("notification-symbolic").size(20),
         notif_content,
         widget::horizontal_space(),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .align_y(Alignment::Center);
 
     // Add dismiss button if notification is dismissable
@@ -400,7 +393,7 @@ fn build_notification_row<'a>(
     }
 
     widget::container(notif_row)
-        .padding([4, 8])
+        .padding([sp.space_xxxs, sp.space_xxs])
         .width(Length::Fill)
         .into()
 }

--- a/cosmic-ext-connected/src/views/send_to.rs
+++ b/cosmic-ext-connected/src/views/send_to.rs
@@ -2,10 +2,10 @@
 
 use crate::app::Message;
 use crate::fl;
-use cosmic::iced::widget::{column, row, text};
+use cosmic::applet;
+use cosmic::iced::widget::{column, row};
 use cosmic::iced::{Alignment, Length};
-use cosmic::widget;
-use cosmic::widget::icon;
+use cosmic::widget::{self, icon, text};
 use cosmic::Element;
 
 /// View parameters for the SendTo submenu.
@@ -22,6 +22,7 @@ pub struct SendToParams<'a> {
 
 /// View for the "Send to device" submenu.
 pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
     let device_type = params.device_type;
     let device_id = params.device_id.to_string();
 
@@ -31,7 +32,9 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
         .on_press(Message::BackFromSendTo);
 
     // Header
-    let header = text(fl!("send-to-title", device = device_type)).size(16);
+    let header = applet::padded_control(
+        text::heading(fl!("send-to-title", device = device_type)),
+    );
 
     // Action list items (consistent with device page style)
     let device_id_for_file = device_id.clone();
@@ -43,59 +46,41 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
     // Share file list item
     let share_file_row = row![
         icon::from_name("document-send-symbolic").size(24),
-        text(fl!("share-file")).size(14),
+        text::body(fl!("share-file")),
         widget::horizontal_space(),
     ]
-    .spacing(12)
+    .spacing(sp.space_xs)
     .align_y(Alignment::Center);
 
-    let share_file_item = widget::button::custom(
-        widget::container(share_file_row)
-            .padding(8)
-            .width(Length::Fill),
-    )
-    .class(cosmic::theme::Button::Text)
-    .on_press(Message::ShareFile(device_id_for_file))
-    .width(Length::Fill);
+    let share_file_item = applet::menu_button(share_file_row)
+        .on_press(Message::ShareFile(device_id_for_file));
 
     // Send clipboard list item
     let send_clipboard_row = row![
         icon::from_name("edit-copy-symbolic").size(24),
-        text(fl!("share-clipboard")).size(14),
+        text::body(fl!("share-clipboard")),
         widget::horizontal_space(),
     ]
-    .spacing(12)
+    .spacing(sp.space_xs)
     .align_y(Alignment::Center);
 
-    let send_clipboard_item = widget::button::custom(
-        widget::container(send_clipboard_row)
-            .padding(8)
-            .width(Length::Fill),
-    )
-    .class(cosmic::theme::Button::Text)
-    .on_press(Message::SendClipboard(device_id_for_clipboard))
-    .width(Length::Fill);
+    let send_clipboard_item = applet::menu_button(send_clipboard_row)
+        .on_press(Message::SendClipboard(device_id_for_clipboard));
 
     // Send ping list item
     let send_ping_row = row![
         icon::from_name("emblem-synchronizing-symbolic").size(24),
-        text(fl!("send-ping")).size(14),
+        text::body(fl!("send-ping")),
         widget::horizontal_space(),
     ]
-    .spacing(12)
+    .spacing(sp.space_xs)
     .align_y(Alignment::Center);
 
-    let send_ping_item = widget::button::custom(
-        widget::container(send_ping_row)
-            .padding(8)
-            .width(Length::Fill),
-    )
-    .class(cosmic::theme::Button::Text)
-    .on_press(Message::SendPing(device_id_for_ping))
-    .width(Length::Fill);
+    let send_ping_item = applet::menu_button(send_ping_row)
+        .on_press(Message::SendPing(device_id_for_ping));
 
     // Share text section
-    let share_text_heading = text(fl!("share-text")).size(14);
+    let share_text_heading = text::heading(fl!("share-text"));
 
     let share_text_input =
         widget::text_input(fl!("share-text-placeholder"), params.share_text_input)
@@ -112,8 +97,8 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
 
     // Status message if present
     let status_bar: Element<Message> = if let Some(msg) = params.status_message {
-        widget::container(text(msg).size(11))
-            .padding([4, 8])
+        widget::container(text::caption(msg))
+            .padding([sp.space_xxxs, sp.space_xxs])
             .width(Length::Fill)
             .class(cosmic::theme::Container::Card)
             .into()
@@ -125,18 +110,21 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
         column![
             back_btn,
             status_bar,
-            widget::divider::horizontal::default(),
             header,
             share_file_item,
             send_clipboard_item,
             send_ping_item,
-            widget::divider::horizontal::default(),
-            share_text_heading,
-            share_text_input,
-            send_text_btn,
+            applet::padded_control(
+                column![
+                    share_text_heading,
+                    share_text_input,
+                    send_text_btn,
+                ]
+                .spacing(sp.space_xxs),
+            ),
         ]
-        .spacing(12)
-        .padding(16),
+        .spacing(sp.space_xs)
+        .padding(sp.space_s),
     )
     .into()
 }

--- a/cosmic-ext-connected/src/views/send_to.rs
+++ b/cosmic-ext-connected/src/views/send_to.rs
@@ -26,14 +26,15 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
     let device_type = params.device_type;
     let device_id = params.device_id.to_string();
 
-    // Back button
-    let back_btn = widget::button::text(fl!("back"))
-        .leading_icon(icon::from_name("go-previous-symbolic").size(16))
-        .on_press(Message::BackFromSendTo);
-
-    // Header
+    // Header with back button and title
     let header = applet::padded_control(
-        text::heading(fl!("send-to-title", device = device_type)),
+        row![
+            widget::button::icon(icon::from_name("go-previous-symbolic"))
+                .on_press(Message::BackFromSendTo),
+            text::heading(fl!("send-to-title", device = device_type)),
+        ]
+        .spacing(sp.space_xxs)
+        .align_y(Alignment::Center),
     );
 
     // Action list items (consistent with device page style)
@@ -108,9 +109,8 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
 
     widget::container(
         column![
-            back_btn,
-            status_bar,
             header,
+            status_bar,
             share_file_item,
             send_clipboard_item,
             send_ping_item,

--- a/cosmic-ext-connected/src/views/settings.rs
+++ b/cosmic-ext-connected/src/views/settings.rs
@@ -14,13 +14,18 @@ use cosmic::Element;
 pub fn view_settings(config: &Config) -> Element<'_, Message> {
     let sp = cosmic::theme::spacing();
 
-    let back_btn = widget::button::text(fl!("back"))
-        .leading_icon(widget::icon::from_name("go-previous-symbolic").size(16))
-        .on_press(Message::ToggleSettings);
+    let header = applet::padded_control(
+        row![
+            widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
+                .on_press(Message::ToggleSettings),
+            text::heading(fl!("settings")),
+        ]
+        .spacing(sp.space_xxs)
+        .align_y(Alignment::Center),
+    );
 
     // General section
     let general_section = settings::section()
-        .title(fl!("settings"))
         .add(
             settings::item::builder(fl!("settings-battery"))
                 .toggler(config.show_battery_percentage, move |_| {
@@ -57,12 +62,11 @@ pub fn view_settings(config: &Config) -> Element<'_, Message> {
 
     widget::container(
         widget::column::with_children(vec![
-            back_btn.into(),
+            header.into(),
             sections.into(),
             notif_nav_btn.into(),
         ])
-        .spacing(sp.space_xxs)
-        .padding(sp.space_s),
+        .spacing(sp.space_xxs),
     )
     .width(Length::Fill)
     .into()
@@ -166,19 +170,20 @@ pub fn view_notification_settings(config: &Config) -> Element<'_, Message> {
         timeout_section.into(),
     ]);
 
-    let header = row![
-        back_btn,
-        text::heading(fl!("notification-settings")),
-    ]
-    .spacing(sp.space_xxs)
-    .align_y(Alignment::Center);
+    let header = applet::padded_control(
+        row![
+            back_btn,
+            text::heading(fl!("notification-settings")),
+        ]
+        .spacing(sp.space_xxs)
+        .align_y(Alignment::Center),
+    );
 
     let content = widget::column::with_children(vec![
         header.into(),
         sections.into(),
     ])
-    .spacing(sp.space_xxs)
-    .padding(sp.space_s);
+    .spacing(sp.space_xxs);
 
     widget::container(widget::scrollable(content))
         .width(Length::Fill)

--- a/cosmic-ext-connected/src/views/settings.rs
+++ b/cosmic-ext-connected/src/views/settings.rs
@@ -4,178 +4,183 @@ use crate::app::{Message, SettingKey};
 use crate::config::Config;
 use crate::constants::notifications::{MAX_TIMEOUT_SECS, MIN_TIMEOUT_SECS};
 use crate::fl;
-use cosmic::iced::widget::{column, row, text};
+use cosmic::applet;
+use cosmic::iced::widget::row;
 use cosmic::iced::{Alignment, Length};
-use cosmic::widget;
+use cosmic::widget::{self, settings, text};
 use cosmic::Element;
 
-/// Render the settings view.
+/// Render the main settings view (general settings + nav to notification settings).
 pub fn view_settings(config: &Config) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
+
     let back_btn = widget::button::text(fl!("back"))
         .leading_icon(widget::icon::from_name("go-previous-symbolic").size(16))
         .on_press(Message::ToggleSettings);
 
-    let mut settings_col = column![
-        back_btn,
-        widget::divider::horizontal::default(),
-        text(fl!("settings")).size(16),
-        view_setting_toggle(
-            fl!("settings-battery"),
-            fl!("settings-battery-desc"),
-            config.show_battery_percentage,
-            SettingKey::ShowBatteryPercentage,
-        ),
-        view_setting_toggle(
-            fl!("settings-offline"),
-            fl!("settings-offline-desc"),
-            config.show_offline_devices,
-            SettingKey::ShowOfflineDevices,
-        ),
-        view_setting_toggle(
-            fl!("settings-notifications"),
-            fl!("settings-notifications-desc"),
-            config.forward_notifications,
-            SettingKey::ForwardNotifications,
-        ),
-        widget::divider::horizontal::default(),
-        view_setting_toggle(
-            fl!("settings-sms-notifications"),
-            fl!("settings-sms-notifications-desc"),
-            config.sms_notifications,
-            SettingKey::SmsNotifications,
-        ),
-    ]
-    .spacing(8)
-    .padding(16);
+    // General section
+    let general_section = settings::section()
+        .title(fl!("settings"))
+        .add(
+            settings::item::builder(fl!("settings-battery"))
+                .toggler(config.show_battery_percentage, move |_| {
+                    Message::ToggleSetting(SettingKey::ShowBatteryPercentage)
+                }),
+        )
+        .add(
+            settings::item::builder(fl!("settings-offline"))
+                .toggler(config.show_offline_devices, move |_| {
+                    Message::ToggleSetting(SettingKey::ShowOfflineDevices)
+                }),
+        )
+        .add(
+            settings::item::builder(fl!("settings-notifications"))
+                .toggler(config.forward_notifications, move |_| {
+                    Message::ToggleSetting(SettingKey::ForwardNotifications)
+                }),
+        );
 
-    // Show sub-settings only when SMS notifications are enabled
+    // Navigation to notification settings sub-page
+    let notif_nav_row = row![
+        widget::icon::from_name("preferences-system-notifications-symbolic").size(24),
+        text::body(fl!("notification-settings")),
+        widget::horizontal_space(),
+        widget::icon::from_name("go-next-symbolic").size(16),
+    ]
+    .spacing(sp.space_xs)
+    .align_y(Alignment::Center);
+
+    let notif_nav_btn = applet::menu_button(notif_nav_row)
+        .on_press(Message::OpenNotificationSettings);
+
+    let sections = settings::view_column(vec![general_section.into()]);
+
+    widget::container(
+        widget::column::with_children(vec![
+            back_btn.into(),
+            sections.into(),
+            notif_nav_btn.into(),
+        ])
+        .spacing(sp.space_xxs)
+        .padding(sp.space_s),
+    )
+    .width(Length::Fill)
+    .into()
+}
+
+/// Render the notification settings sub-page.
+pub fn view_notification_settings(config: &Config) -> Element<'_, Message> {
+    let sp = cosmic::theme::spacing();
+
+    let back_btn = widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
+        .on_press(Message::BackFromNotificationSettings);
+
+    // SMS notifications section
+    let mut sms_section = settings::section()
+        .title(fl!("settings-sms-section"))
+        .add(
+            settings::item::builder(fl!("settings-sms-notifications"))
+                .toggler(config.sms_notifications, move |_| {
+                    Message::ToggleSetting(SettingKey::SmsNotifications)
+                }),
+        );
+
     if config.sms_notifications {
-        settings_col = settings_col
-            .push(view_setting_toggle(
-                fl!("settings-sms-show-sender"),
-                fl!("settings-sms-show-sender-desc"),
-                config.sms_notification_show_sender,
-                SettingKey::SmsShowSender,
-            ))
-            .push(view_setting_toggle(
-                fl!("settings-sms-show-content"),
-                fl!("settings-sms-show-content-desc"),
-                config.sms_notification_show_content,
-                SettingKey::SmsShowContent,
-            ));
+        sms_section = sms_section
+            .add(
+                settings::item::builder(fl!("settings-sms-show-sender"))
+                    .toggler(config.sms_notification_show_sender, move |_| {
+                        Message::ToggleSetting(SettingKey::SmsShowSender)
+                    }),
+            )
+            .add(
+                settings::item::builder(fl!("settings-sms-show-content"))
+                    .toggler(config.sms_notification_show_content, move |_| {
+                        Message::ToggleSetting(SettingKey::SmsShowContent)
+                    }),
+            );
     }
 
     // Call notifications section
-    settings_col = settings_col
-        .push(widget::divider::horizontal::default())
-        .push(view_setting_toggle(
-            fl!("settings-call-notifications"),
-            fl!("settings-call-notifications-desc"),
-            config.call_notifications,
-            SettingKey::CallNotifications,
-        ));
+    let mut call_section = settings::section()
+        .title(fl!("settings-call-section"))
+        .add(
+            settings::item::builder(fl!("settings-call-notifications"))
+                .toggler(config.call_notifications, move |_| {
+                    Message::ToggleSetting(SettingKey::CallNotifications)
+                }),
+        );
 
-    // Show sub-settings only when call notifications are enabled
     if config.call_notifications {
-        settings_col = settings_col
-            .push(view_setting_toggle(
-                fl!("settings-call-show-name"),
-                fl!("settings-call-show-name-desc"),
-                config.call_notification_show_name,
-                SettingKey::CallShowName,
-            ))
-            .push(view_setting_toggle(
-                fl!("settings-call-show-number"),
-                fl!("settings-call-show-number-desc"),
-                config.call_notification_show_number,
-                SettingKey::CallShowNumber,
-            ));
+        call_section = call_section
+            .add(
+                settings::item::builder(fl!("settings-call-show-name"))
+                    .toggler(config.call_notification_show_name, move |_| {
+                        Message::ToggleSetting(SettingKey::CallShowName)
+                    }),
+            )
+            .add(
+                settings::item::builder(fl!("settings-call-show-number"))
+                    .toggler(config.call_notification_show_number, move |_| {
+                        Message::ToggleSetting(SettingKey::CallShowNumber)
+                    }),
+            );
     }
 
     // File notifications section
-    settings_col = settings_col
-        .push(widget::divider::horizontal::default())
-        .push(view_setting_toggle(
-            fl!("settings-file-notifications"),
-            fl!("settings-file-notifications-desc"),
-            config.file_notifications,
-            SettingKey::FileNotifications,
-        ));
+    let file_section = settings::section()
+        .title(fl!("settings-file-section"))
+        .add(
+            settings::item::builder(fl!("settings-file-notifications"))
+                .toggler(config.file_notifications, move |_| {
+                    Message::ToggleSetting(SettingKey::FileNotifications)
+                }),
+        );
 
-    // Notification timeout slider
-    settings_col = settings_col
-        .push(widget::divider::horizontal::default())
-        .push(view_setting_slider(
-            fl!("settings-notification-timeout"),
-            fl!("settings-notification-timeout-desc"),
-            config.notification_timeout_secs,
-            MIN_TIMEOUT_SECS..=MAX_TIMEOUT_SECS,
-            Message::SetNotificationTimeout,
-        ));
-
-    widget::container(settings_col).width(Length::Fill).into()
-}
-
-/// Render a setting row with a slider control.
-fn view_setting_slider(
-    title: String,
-    description: String,
-    value: u32,
-    range: std::ops::RangeInclusive<u32>,
-    on_change: fn(u32) -> Message,
-) -> Element<'static, Message> {
-    let label = fl!("notification-timeout-seconds", seconds = value.to_string());
-
-    let slider = widget::slider(range, value, on_change);
-
-    let text_col = column![
-        text(title).size(14),
-        text(description).size(11).wrapping(text::Wrapping::Word),
-    ]
-    .spacing(2)
-    .width(Length::Fill);
-
-    let slider_row = row![
+    // Notification timeout section
+    let label = fl!(
+        "notification-timeout-seconds",
+        seconds = config.notification_timeout_secs.to_string()
+    );
+    let slider = widget::slider(
+        MIN_TIMEOUT_SECS..=MAX_TIMEOUT_SECS,
+        config.notification_timeout_secs,
+        Message::SetNotificationTimeout,
+    );
+    let slider_control = row![
         slider,
-        text(label).size(12).width(Length::Fixed(36.0)),
+        widget::text::caption(label).width(Length::Fixed(36.0)),
     ]
-    .spacing(8)
+    .spacing(sp.space_xxs)
     .align_y(Alignment::Center)
     .width(Length::Fixed(160.0));
 
-    let setting_row = row![text_col, slider_row]
-        .spacing(12)
-        .align_y(Alignment::Center);
+    let timeout_section = settings::section()
+        .title(fl!("settings-notification-timeout"))
+        .add(settings::item::builder("").control(slider_control));
 
-    widget::container(setting_row)
-        .padding(12)
-        .width(Length::Fill)
-        .into()
-}
+    let sections = settings::view_column(vec![
+        sms_section.into(),
+        call_section.into(),
+        file_section.into(),
+        timeout_section.into(),
+    ]);
 
-/// Render a single setting toggle row.
-pub fn view_setting_toggle(
-    title: String,
-    description: String,
-    enabled: bool,
-    key: SettingKey,
-) -> Element<'static, Message> {
-    let toggle = widget::toggler(enabled).on_toggle(move |_| Message::ToggleSetting(key.clone()));
-
-    // Use width constraint on text column to ensure toggle alignment
-    let text_col = column![
-        text(title).size(14),
-        text(description).size(11).wrapping(text::Wrapping::Word),
+    let header = row![
+        back_btn,
+        text::heading(fl!("notification-settings")),
     ]
-    .spacing(2)
-    .width(Length::Fill);
+    .spacing(sp.space_xxs)
+    .align_y(Alignment::Center);
 
-    let setting_row = row![text_col, toggle,]
-        .spacing(12)
-        .align_y(Alignment::Center);
+    let content = widget::column::with_children(vec![
+        header.into(),
+        sections.into(),
+    ])
+    .spacing(sp.space_xxs)
+    .padding(sp.space_s);
 
-    widget::container(setting_row)
-        .padding(12)
+    widget::container(widget::scrollable(content))
         .width(Length::Fill)
         .into()
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded pixel values with `cosmic::theme::spacing()` tokens and semantic typography (`text::heading`, `text::body`, `text::caption`) across all view files
- Adopt official libcosmic widgets (`applet::menu_button`, `applet::padded_control`, `settings::section`) instead of custom button/container patterns
- Split settings into a compact main page (3 toggles + nav button) and a notification settings sub-page to fix the duration slider being cut off by popup height
- Streamline all settings labels by removing redundant descriptions
- Add `padded_control(divider::horizontal)` dividers between major sections on the device page and media player
- Wrap all view headers in `applet::padded_control` for consistent horizontal alignment
- Standardize back buttons to icon-only `go-previous-symbolic` across all views
- Add tooltip to the new message button on the conversation list

## Test plan
- [ ] Verify all views render correctly: device list, device page, settings, notification settings, send-to, SMS conversations, message thread, new message, media controls
- [ ] Verify settings toggles persist correctly across both settings pages
- [ ] Verify notification settings sub-page navigation (forward and back)
- [ ] Verify dividers appear between sections on device page and media player
- [ ] Verify back buttons work consistently across all views
- [ ] Verify tooltip appears on hover over the + button in conversation list
- [ ] Verify conversation list scrolls when content overflows
- [ ] Verify duration slider is fully visible on the notification settings sub-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)