### PR TITLE
Fix conversation list sync dying on cold start

### DIFF
--- a/cosmic-ext-connected/src/constants.rs
+++ b/cosmic-ext-connected/src/constants.rs
@@ -46,6 +46,16 @@ pub mod sms {
     /// Needed because the local store may be empty/sparse after a reboot.
     pub const PHONE_RESPONSE_TIMEOUT_MS: u64 = 8000;
 
+    /// How long to wait for the phone to start responding with conversation
+    /// list signals on cold start when no cache exists (milliseconds).
+    pub const CONVERSATION_LIST_PHONE_WAIT_MS: u64 = 8000;
+
+    /// Activity timeout for conversation list sync (milliseconds).
+    /// After the first live signal, if no new signals arrive within this
+    /// duration, sync is complete. Longer than SIGNAL_ACTIVITY_TIMEOUT_MS
+    /// (500ms) because conversation list signals arrive with larger gaps.
+    pub const CONVERSATION_LIST_ACTIVITY_TIMEOUT_MS: u64 = 3000;
+
     /// Interval for polling in fallback mode (milliseconds).
     pub const FALLBACK_POLLING_INTERVAL_MS: u64 = 500;
 


### PR DESCRIPTION
## Summary
- Replace `received_any_data` boolean + `last_activity` timestamp with explicit `phone_deadline` and `activity_deadline` Instants in conversation list subscription
- On cold start with stale cache, the old 500ms activity timeout would fire before the phone could respond (1-5s network RTT), killing the subscription at ~3 conversations
- Cached data no longer arms the activity timeout — a 3s (warm) or 8s (cold) phone deadline waits for the first live signal, then a 3s activity deadline resets on each signal until sync completes
- Add `Done` terminal state replacing the `Init { device_id: String::new() }` hack

## Test plan
- [ ] Cold start (kill kdeconnectd, restart) → open SMS Messages → all conversations load incrementally
- [ ] Back → re-open SMS → cached data shown immediately → sync completes in ~3s
- [ ] Phone disconnected → subscription exits cleanly at phone_deadline (no 20s hang)
- [ ] Check logs: `journalctl --user -f | grep cosmic-ext-connected` — verify "activity timeout" or "phone never responded" messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)