### PR TITLE
Fix subscription reliability and reduce message loading wait

### DIFF
--- a/cosmic-ext-connected/src/constants.rs
+++ b/cosmic-ext-connected/src/constants.rs
@@ -40,11 +40,15 @@ pub mod sms {
     /// Safety net if conversationLoaded signal never arrives.
     pub const MESSAGE_SUBSCRIPTION_TIMEOUT_SECS: u64 = 20;
 
-    /// Activity timeout after conversationLoaded for phone response data (milliseconds).
-    /// After the local store read completes (conversationLoaded signal), we keep listening
-    /// this long for additional messages from the phone. Resets on each D-Bus signal.
-    /// Needed because the local store may be empty/sparse after a reboot.
+    /// How long to wait for the phone to start responding with message data after
+    /// conversationLoaded (milliseconds). Only checked when no phone messages have
+    /// arrived yet (activity_deadline is None). Needs to be long enough for network RTT.
     pub const PHONE_RESPONSE_TIMEOUT_MS: u64 = 8000;
+
+    /// Activity timeout for phone message data (milliseconds). Once the first phone
+    /// message arrives, this shorter timeout takes over. Reset on each matching signal.
+    /// If no new messages arrive within this window, the subscription completes.
+    pub const PHONE_ACTIVITY_TIMEOUT_MS: u64 = 3000;
 
     /// How long to wait for the phone to start responding with conversation
     /// list signals on cold start when no cache exists (milliseconds).


### PR DESCRIPTION
## Summary
- **B1**: Clear all subscription flags (`conversation_list_subscription_active`, `message_sync_active`) on `SmsError` to prevent permanently stuck subscriptions
- **B3**: Reuse in-memory cached contacts for SMS notifications instead of loading all vCard files from disk on every notification. Skips contact resolution entirely when `show_sender` is disabled.
- **C1**: Split message subscription's single 8s `phone_deadline` into two deadlines: `phone_deadline` (8s) for waiting for the phone to start responding, and `activity_deadline` (3s) that takes over once messages are flowing. Reduces post-load wait from up to 8s to 3s.

## Test plan
- [ ] Open SMS view, verify conversation list loads normally
- [ ] Open a conversation with many messages, verify messages load without duplicates
- [ ] Verify message loading completes faster (3s activity timeout vs previous 8s)
- [ ] Trigger an SMS notification while contacts are cached — verify no disk I/O delay
- [ ] Simulate D-Bus error (e.g., stop kdeconnectd) — verify subscription flags reset and don't get stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)