### PR TITLE
Add MMS attachment viewing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ i18n-embed = { version = "0.15", features = ["fluent-system", "desktop-requester
 i18n-embed-fl = "0.9"
 rust-embed = "8"
 
+# Base64 decoding (MMS attachment thumbnails)
+base64 = "0.22"
+
 # Date/time
 chrono = "0.4"
 

--- a/cosmic-ext-connected/Cargo.toml
+++ b/cosmic-ext-connected/Cargo.toml
@@ -21,6 +21,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 rfd.workspace = true
 chrono.workspace = true
+base64.workspace = true
 i18n-embed.workspace = true
 i18n-embed-fl.workspace = true
 rust-embed.workspace = true

--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -176,3 +176,8 @@ group-sms-warning = Message sent, but group replies may not be delivered. If it 
 pairing-accepted = Pairing accepted
 pairing-rejected = Pairing rejected
 unpaired = Unpaired from device
+
+# Attachments
+attachment = Attachment
+loading-attachment = Loading attachment...
+attachment-failed = Failed to load attachment

--- a/cosmic-ext-connected/src/sms/conversation_subscription.rs
+++ b/cosmic-ext-connected/src/sms/conversation_subscription.rs
@@ -182,12 +182,14 @@ pub fn conversation_list_subscription(
                             tracing::info!("Got {} cached conversation values", cached.len());
                             for value in &cached {
                                 if let Some(sms_msg) = parse_sms_message(value) {
+                                    let has_attachments = !sms_msg.attachments.is_empty();
                                     initial_conversations.push(ConversationSummary {
                                         thread_id: sms_msg.thread_id,
                                         addresses: sms_msg.addresses,
                                         last_message: sms_msg.body,
                                         timestamp: sms_msg.date,
                                         unread: !sms_msg.read,
+                                        has_attachments,
                                     });
                                 }
                             }
@@ -457,12 +459,14 @@ pub fn conversation_list_subscription(
                                                     let body = msg.body();
                                                     if let Ok(value) = body.deserialize::<zbus::zvariant::OwnedValue>() {
                                                         if let Some(sms_msg) = parse_sms_message(&value) {
+                                                            let has_attachments = !sms_msg.attachments.is_empty();
                                                             let conversation = ConversationSummary {
                                                                 thread_id: sms_msg.thread_id,
                                                                 addresses: sms_msg.addresses,
                                                                 last_message: sms_msg.body,
                                                                 timestamp: sms_msg.date,
                                                                 unread: !sms_msg.read,
+                                                                has_attachments,
                                                             };
                                                             tracing::debug!(
                                                                 "conversationCreated: thread {} for device {}",
@@ -495,12 +499,14 @@ pub fn conversation_list_subscription(
                                                     let body = msg.body();
                                                     if let Ok(value) = body.deserialize::<zbus::zvariant::OwnedValue>() {
                                                         if let Some(sms_msg) = parse_sms_message(&value) {
+                                                            let has_attachments = !sms_msg.attachments.is_empty();
                                                             let conversation = ConversationSummary {
                                                                 thread_id: sms_msg.thread_id,
                                                                 addresses: sms_msg.addresses,
                                                                 last_message: sms_msg.body,
                                                                 timestamp: sms_msg.date,
                                                                 unread: !sms_msg.read,
+                                                                has_attachments,
                                                             };
                                                             tracing::debug!(
                                                                 "conversationUpdated: thread {} for device {}",

--- a/io.github.nwxnw.cosmic-ext-connected.json
+++ b/io.github.nwxnw.cosmic-ext-connected.json
@@ -15,7 +15,8 @@
     "--talk-name=com.system76.CosmicSettingsDaemon",
     "--talk-name=org.freedesktop.Notifications",
     "--filesystem=xdg-config/cosmic:rw",
-    "--filesystem=xdg-data/kpeoplevcard:ro"
+    "--filesystem=xdg-data/kpeoplevcard:ro",
+    "--filesystem=xdg-cache/kdeconnect.daemon:ro"
   ],
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin",

--- a/kdeconnect-dbus/src/plugins/mod.rs
+++ b/kdeconnect-dbus/src/plugins/mod.rs
@@ -22,7 +22,7 @@ pub use notifications::{NotificationInfo, NotificationProxy, NotificationsProxy}
 pub use ping::PingProxy;
 pub use share::ShareProxy;
 pub use sms::{
-    is_address_valid, parse_conversations, parse_messages, parse_sms_message, ConversationSummary,
-    ConversationsProxy, MessageType, SmsMessage, SmsProxy, MAX_CONVERSATIONS,
+    is_address_valid, parse_conversations, parse_messages, parse_sms_message, Attachment,
+    ConversationSummary, ConversationsProxy, MessageType, SmsMessage, SmsProxy, MAX_CONVERSATIONS,
 };
 pub use telephony::TelephonyProxy;


### PR DESCRIPTION
## Summary
- Parse MMS attachment metadata from D-Bus field 9 (`a(xsss)`: part ID, MIME type, base64 thumbnail, unique identifier)
- Display inline base64-decoded image thumbnails in message bubbles (clickable to open full-size)
- Show attachment indicator icon in the conversation list for MMS messages
- Click-to-open full-size attachments via `xdg-open` with cache-first lookup at `~/.cache/kdeconnect.daemon/<device>/`
- Add Flatpak sandbox permission for KDE Connect daemon cache directory

## Test plan
- [ ] Send an MMS with an image from phone → thumbnail appears in message bubble, attachment icon in conversation list
- [ ] Click thumbnail → full-size image opens with default viewer via `xdg-open`
- [ ] MMS with only images (no text body) → renders cleanly without empty text
- [ ] MMS with text + image → both text and thumbnail display in the bubble
- [ ] Text-only SMS → no regressions, renders as before
- [ ] Non-image attachments (video, audio) → show icon + MIME type label placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)