### PR TITLE
Add multi-recipient (group) new message support

### DIFF
--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -138,6 +138,7 @@ hold-to-copy = Hold to copy
 
 # New message
 new-message = New Message
+new-group-message = New Group Message
 to = To:
 recipient-placeholder = Type a name to search contacts, or enter a phone number
 type-message = Type a message...

--- a/cosmic-ext-connected/src/sms/send.rs
+++ b/cosmic-ext-connected/src/sms/send.rs
@@ -63,11 +63,11 @@ pub async fn send_sms_async(
     }
 }
 
-/// Send an SMS to a new recipient (creates or adds to existing conversation).
+/// Send an SMS to one or more recipients (creates or adds to existing conversation).
 pub async fn send_new_sms_async(
     conn: Arc<Mutex<Connection>>,
     device_id: String,
-    recipient: String,
+    recipients: Vec<String>,
     message: String,
 ) -> Message {
     let conn = conn.lock().await;
@@ -92,9 +92,12 @@ pub async fn send_new_sms_async(
         }
     };
 
-    // Format address as D-Bus struct for KDE Connect
+    // Format addresses as D-Bus structs for KDE Connect
     // KDE Connect's ConversationAddress is a struct containing a single string: (s)
-    let addresses: Vec<Value<'_>> = vec![Value::Structure(Structure::from((recipient.clone(),)))];
+    let addresses: Vec<Value<'_>> = recipients
+        .iter()
+        .map(|r| Value::Structure(Structure::from((r.clone(),))))
+        .collect();
     let empty_attachments: Vec<Value<'_>> = vec![];
 
     match conversations_proxy


### PR DESCRIPTION
## Summary
- Replace single-recipient text input with a chip-based UI supporting multiple recipients
- Recipients are validated and deduplicated via phone suffix matching (last 10 digits)
- Contact suggestions automatically filter out already-added recipients
- Header dynamically switches to "New Group Message" with 2+ recipients
- `sendWithoutConversation` D-Bus call now passes all recipient addresses

## Test plan
- [ ] Single recipient: type number → Enter → type body → Send
- [ ] Multi-recipient: add 2-3 recipients (mix contact selection + manual entry) → Send
- [ ] Duplicate prevention: add number, try adding same with different formatting (e.g. `+1-555-123-4567` vs `5551234567`)
- [ ] Remove chip: click X, verify send button disables when no recipients remain
- [ ] Heading: "New Message" with 0-1 recipients, "New Group Message" with 2+
- [ ] Suggestion filtering: add a contact, search same name, verify excluded from suggestions
- [ ] Input action icon: spacer when empty, green + when valid, error icon when invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)