### PR TITLE
Restrict accent color to actionable UI

### DIFF
--- a/cosmic-ext-connected/src/media/views.rs
+++ b/cosmic-ext-connected/src/media/views.rs
@@ -27,8 +27,7 @@ pub fn view_media_controls(params: MediaControlsParams<'_>) -> Element<'_, Messa
             widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
                 .class(cosmic::theme::Button::Link)
                 .on_press(Message::CloseMediaView),
-            text::heading(format!("{} - {}", fl!("media"), device_name))
-                .class(cosmic::theme::Text::Accent),
+            text::heading(format!("{} - {}", fl!("media"), device_name)),
             widget::space::horizontal(),
         ]
         .spacing(sp.space_xxs)

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -163,8 +163,7 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
         widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
             .class(cosmic::theme::Button::Link)
             .on_press(Message::CloseSmsView),
-        text::heading(fl!("messages-title", device = device_name))
-            .class(cosmic::theme::Text::Accent),
+        text::heading(fl!("messages-title", device = device_name)),
     ]
     .spacing(sp.space_xxs)
     .align_y(Alignment::Center);
@@ -358,7 +357,7 @@ pub fn view_message_thread(params: MessageThreadParams<'_>) -> Element<'_, Messa
         widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
             .class(cosmic::theme::Button::Link)
             .on_press(Message::CloseConversation),
-        text::heading(display_name).class(cosmic::theme::Text::Accent),
+        text::heading(display_name),
     ]
     .spacing(sp.space_xxs)
     .align_y(Alignment::Center);
@@ -610,7 +609,7 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
             widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
                 .class(cosmic::theme::Button::Link)
                 .on_press(Message::CloseNewMessage),
-            text::heading(heading_text).class(cosmic::theme::Text::Accent),
+            text::heading(heading_text),
             widget::space::horizontal(),
         ]
         .spacing(sp.space_xxs)

--- a/cosmic-ext-connected/src/ui/device_page.rs
+++ b/cosmic-ext-connected/src/ui/device_page.rs
@@ -5,10 +5,10 @@
 use crate::app::{DeviceInfo, Message};
 use crate::fl;
 use cosmic::applet;
-use cosmic::iced::widget::{column, row, svg, tooltip};
+use cosmic::iced::widget::{column, row, tooltip};
 use cosmic::iced::{Alignment, Length};
 use cosmic::widget::{self, icon, text};
-use cosmic::{theme, Element};
+use cosmic::Element;
 use kdeconnect_dbus::plugins::NotificationInfo;
 
 /// Render the device detail page.
@@ -21,18 +21,14 @@ pub fn view<'a>(device: &'a DeviceInfo, status_message: Option<&'a str>) -> Elem
             .class(cosmic::theme::Button::Link)
             .on_press(Message::BackToList);
 
-        let device_icon = icon::from_name("io.github.nwxnw.cosmic-ext-connected-symbolic")
-            .size(48)
-            .icon()
-            .class(theme::Svg::custom(|theme| svg::Style {
-                color: Some(theme.cosmic().accent_text_color().into()),
-            }));
+        let device_icon =
+            icon::from_name("io.github.nwxnw.cosmic-ext-connected-symbolic").size(48);
 
         let mut info_row = row![
             back_btn,
             device_icon,
             column![
-                text::title4(device.name.clone()).class(cosmic::theme::Text::Accent),
+                text::title4(device.name.clone()),
                 text::caption(device.device_type.clone()),
             ]
             .spacing(sp.space_xxxs),
@@ -181,7 +177,7 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
     };
     let connected_element = row![
         icon::from_name(connected_icon_name).size(16),
-        text::caption(fl!("connected")).class(cosmic::theme::Text::Accent),
+        text::caption(fl!("connected")),
     ]
     .spacing(sp.space_xxxs)
     .align_y(Alignment::Center);
@@ -194,7 +190,7 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
     };
     let paired_element = row![
         icon::from_name(paired_icon_name).size(16),
-        text::caption(fl!("paired")).class(cosmic::theme::Text::Accent),
+        text::caption(fl!("paired")),
     ]
     .spacing(sp.space_xxxs)
     .align_y(Alignment::Center);
@@ -206,7 +202,7 @@ fn build_status_row<'a>(device: &'a DeviceInfo) -> Element<'a, Message> {
             if level >= 0 {
                 let battery_icon_name = get_battery_icon_name(level, charging);
                 row![
-                    text::caption(format!("{}%", level)).class(cosmic::theme::Text::Accent),
+                    text::caption(format!("{}%", level)),
                     icon::from_name(battery_icon_name).size(24),
                 ]
                 .spacing(sp.space_xxxs)

--- a/cosmic-ext-connected/src/views/send_to.rs
+++ b/cosmic-ext-connected/src/views/send_to.rs
@@ -32,8 +32,7 @@ pub fn view_send_to(params: SendToParams<'_>) -> Element<'_, Message> {
             widget::button::icon(icon::from_name("go-previous-symbolic"))
                 .class(cosmic::theme::Button::Link)
                 .on_press(Message::BackFromSendTo),
-            text::heading(fl!("send-to-title", device = device_type))
-                .class(cosmic::theme::Text::Accent),
+            text::heading(fl!("send-to-title", device = device_type)),
         ]
         .spacing(sp.space_xxs)
         .align_y(Alignment::Center),

--- a/cosmic-ext-connected/src/views/settings.rs
+++ b/cosmic-ext-connected/src/views/settings.rs
@@ -19,7 +19,7 @@ pub fn view_settings(config: &Config) -> Element<'_, Message> {
             widget::button::icon(widget::icon::from_name("go-previous-symbolic"))
                 .class(cosmic::theme::Button::Link)
                 .on_press(Message::ToggleSettings),
-            text::heading(fl!("settings")).class(cosmic::theme::Text::Accent),
+            text::heading(fl!("settings")),
         ]
         .spacing(sp.space_xxs)
         .align_y(Alignment::Center),
@@ -165,7 +165,7 @@ pub fn view_notification_settings(config: &Config) -> Element<'_, Message> {
     let header = applet::padded_control(
         row![
             back_btn,
-            text::heading(fl!("notification-settings")).class(cosmic::theme::Text::Accent),
+            text::heading(fl!("notification-settings")),
         ]
         .spacing(sp.space_xxs)
         .align_y(Alignment::Center),


### PR DESCRIPTION
## Summary

Topic 3 of the [v0.4.0 plan](https://github.com/nwxnw/cosmic-ext-connected/blob/main/CHANGELOG.md) — UI discipline: accent color should indicate interactivity or a user-actionable state change, not decorate headings or informational captions.

Removes `Text::Accent` (and one decorative `theme::Svg::custom` tint) from 12 sites. All 12 were labels, headings, or decorative tints — no actionable text currently uses accent styling, so there is no behavior change beyond the color swap.

| File | Line | Site |
|---|---|---|
| `ui/device_page.rs` | 24 | Device icon tint (decorative) |
| `ui/device_page.rs` | 35 | Device name `title4` |
| `ui/device_page.rs` | 184 | "Connected" caption |
| `ui/device_page.rs` | 197 | "Paired" caption |
| `ui/device_page.rs` | 209 | Battery `%` caption |
| `views/settings.rs` | 22 | "Settings" heading |
| `views/settings.rs` | 168 | "Notification settings" heading |
| `views/send_to.rs` | 36 | "Send to {device}" heading |
| `media/views.rs` | 31 | "Media - {device}" heading |
| `sms/views.rs` | 167 | "Messages - {device}" heading |
| `sms/views.rs` | 361 | Thread display-name heading |
| `sms/views.rs` | 613 | "New Message" / "New Group Message" heading |

Accent styling is preserved on back buttons (`Button::Link`) and pair/unpair/accept/reject buttons — those are genuinely actionable and already theme-driven, unchanged here.

