### PR TITLE
Pair-state subscription reliability (v0.4.0 Topic 4)

### DIFF
--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -993,14 +993,25 @@ impl Application for ConnectApplet {
                 // D-Bus signal received - debounce to avoid excessive refreshes
                 // Require at least 3 seconds between signal-triggered refreshes
                 let now = std::time::Instant::now();
-                if now.duration_since(self.last_signal_refresh)
-                    < std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS)
-                {
+                let elapsed = now.duration_since(self.last_signal_refresh);
+                let debounce = std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS);
+                if elapsed < debounce {
+                    // [topic4-baseline] temporary: trace dropped signals
+                    tracing::info!(
+                        "[topic4-baseline] DEBOUNCED ({}ms since last, debounce={}ms)",
+                        elapsed.as_millis(),
+                        debounce.as_millis()
+                    );
                     return cosmic::app::Task::none();
                 }
 
                 if let Some(conn) = &self.dbus_connection {
                     tracing::debug!("D-Bus signal received, refreshing devices");
+                    // [topic4-baseline] temporary: trace served signals
+                    tracing::info!(
+                        "[topic4-baseline] SERVED ({}ms since last)",
+                        elapsed.as_millis()
+                    );
                     self.last_signal_refresh = now;
                     return cosmic::app::Task::perform(
                         fetch_devices_async(conn.clone()),

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -52,20 +52,25 @@ use zbus::Connection;
 
 // [topic4-baseline] temporary diagnostic logger. Writes to a host file
 // because the COSMIC panel applet does not surface tracing output via
-// journalctl. Remove this fn (and all callers tagged [topic4-baseline])
-// before this branch merges.
+// journalctl. PID prefix lets us filter to a single applet instance on
+// multi-monitor setups (one process per panel). Single write_all call so
+// concurrent writers from sibling instances don't interleave at the
+// syscall boundary. Remove this fn (and all callers tagged
+// [topic4-baseline]) before this branch merges.
 fn topic4_log(msg: &str) {
     use std::io::Write;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
+    let pid = std::process::id();
+    let line = format!("{} {} {}\n", pid, now_ms, msg);
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open("/tmp/cosmic-ext-connected-pair-debug.log")
     {
-        let _ = writeln!(f, "{} {}", now_ms, msg);
+        let _ = f.write_all(line.as_bytes());
     }
 }
 

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -50,30 +50,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use zbus::Connection;
 
-// [topic4-baseline] temporary diagnostic logger. Writes to a host file
-// because the COSMIC panel applet does not surface tracing output via
-// journalctl. PID prefix lets us filter to a single applet instance on
-// multi-monitor setups (one process per panel). Single write_all call so
-// concurrent writers from sibling instances don't interleave at the
-// syscall boundary. Remove this fn (and all callers tagged
-// [topic4-baseline]) before this branch merges.
-fn topic4_log(msg: &str) {
-    use std::io::Write;
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
-    let pid = std::process::id();
-    let line = format!("{} {} {}\n", pid, now_ms, msg);
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/tmp/cosmic-ext-connected-pair-debug.log")
-    {
-        let _ = f.write_all(line.as_bytes());
-    }
-}
-
 /// Messages that drive the applet's state changes.
 #[derive(Debug, Clone)]
 #[allow(clippy::enum_variant_names)] // NewMessage variants refer to SMS, not the enum
@@ -812,8 +788,6 @@ impl Application for ConnectApplet {
                     self.signal_refresh_pending = false;
                     if let Some(conn) = &self.dbus_connection {
                         self.last_signal_refresh = std::time::Instant::now();
-                        // [topic4-baseline] temporary: trace deferred refresh
-                        topic4_log("FLUSHED-PENDING (re-fetching after debounced signals)");
                         return cosmic::app::Task::perform(
                             fetch_devices_async(conn.clone()),
                             cosmic::Action::App,
@@ -1045,19 +1019,11 @@ impl Application for ConnectApplet {
                 let debounce = std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS);
                 if elapsed < debounce {
                     self.signal_refresh_pending = true;
-                    // [topic4-baseline] temporary: trace dropped signals (now flagged pending)
-                    topic4_log(&format!(
-                        "DEBOUNCED+PENDING ({}ms since last, debounce={}ms)",
-                        elapsed.as_millis(),
-                        debounce.as_millis()
-                    ));
                     return cosmic::app::Task::none();
                 }
 
                 if let Some(conn) = &self.dbus_connection {
                     tracing::debug!("D-Bus signal received, refreshing devices");
-                    // [topic4-baseline] temporary: trace served signals
-                    topic4_log(&format!("SERVED ({}ms since last)", elapsed.as_millis()));
                     self.last_signal_refresh = now;
                     // The dispatched fetch will see the latest state, so any
                     // signal-triggered staleness up to this moment is covered.

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -50,6 +50,25 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use zbus::Connection;
 
+// [topic4-baseline] temporary diagnostic logger. Writes to a host file
+// because the COSMIC panel applet does not surface tracing output via
+// journalctl. Remove this fn (and all callers tagged [topic4-baseline])
+// before this branch merges.
+fn topic4_log(msg: &str) {
+    use std::io::Write;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/cosmic-ext-connected-pair-debug.log")
+    {
+        let _ = writeln!(f, "{} {}", now_ms, msg);
+    }
+}
+
 /// Messages that drive the applet's state changes.
 #[derive(Debug, Clone)]
 #[allow(clippy::enum_variant_names)] // NewMessage variants refer to SMS, not the enum
@@ -997,21 +1016,18 @@ impl Application for ConnectApplet {
                 let debounce = std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS);
                 if elapsed < debounce {
                     // [topic4-baseline] temporary: trace dropped signals
-                    tracing::info!(
-                        "[topic4-baseline] DEBOUNCED ({}ms since last, debounce={}ms)",
+                    topic4_log(&format!(
+                        "DEBOUNCED ({}ms since last, debounce={}ms)",
                         elapsed.as_millis(),
                         debounce.as_millis()
-                    );
+                    ));
                     return cosmic::app::Task::none();
                 }
 
                 if let Some(conn) = &self.dbus_connection {
                     tracing::debug!("D-Bus signal received, refreshing devices");
                     // [topic4-baseline] temporary: trace served signals
-                    tracing::info!(
-                        "[topic4-baseline] SERVED ({}ms since last)",
-                        elapsed.as_millis()
-                    );
+                    topic4_log(&format!("SERVED ({}ms since last)", elapsed.as_millis()));
                     self.last_signal_refresh = now;
                     return cosmic::app::Task::perform(
                         fetch_devices_async(conn.clone()),

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -2,7 +2,7 @@
 
 use crate::config::Config;
 use crate::constants::{
-    dbus::SIGNAL_REFRESH_DEBOUNCE_SECS,
+    dbus::{PENDING_REFRESH_TICK_SECS, SIGNAL_REFRESH_DEBOUNCE_SECS},
     notifications::{MAX_TIMEOUT_SECS, MIN_TIMEOUT_SECS},
     refresh,
 };
@@ -124,6 +124,9 @@ pub enum Message {
     ClearStatusMessage,
     /// D-Bus signal received indicating device state changed
     DbusSignalReceived,
+    /// Periodic tick to flush a pending refresh if the debounce window has cleared
+    /// and no fetch is in flight to consume the flag naturally.
+    CheckPendingRefresh,
 
     // Notification actions
     /// Dismiss a notification on a device
@@ -1032,6 +1035,29 @@ impl Application for ConnectApplet {
                         fetch_devices_async(conn.clone()),
                         cosmic::Action::App,
                     );
+                }
+            }
+            Message::CheckPendingRefresh => {
+                // Periodic tick: if a signal was debounced and no fetch is in
+                // flight to consume the pending flag via DevicesUpdated, flush
+                // it once the debounce window has cleared. Without this, a
+                // user accepting a pair request quickly after the request was
+                // sent could leave the UI stuck on "waiting for acceptance"
+                // until the next ambient signal (battery refresh, etc.).
+                if self.signal_refresh_pending {
+                    let now = std::time::Instant::now();
+                    let elapsed = now.duration_since(self.last_signal_refresh);
+                    let debounce = std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS);
+                    if elapsed >= debounce {
+                        if let Some(conn) = &self.dbus_connection {
+                            self.signal_refresh_pending = false;
+                            self.last_signal_refresh = now;
+                            return cosmic::app::Task::perform(
+                                fetch_devices_async(conn.clone()),
+                                cosmic::Action::App,
+                            );
+                        }
+                    }
                 }
             }
 
@@ -2719,6 +2745,11 @@ impl Application for ConnectApplet {
                     }
                     Message::ConfigChanged(update.config)
                 }),
+            // Periodically check for a deferred refresh if signals were
+            // dropped by the debounce window with no fetch in flight to
+            // flush the pending flag.
+            cosmic::iced::time::every(std::time::Duration::from_secs(PENDING_REFRESH_TICK_SECS))
+                .map(|_| Message::CheckPendingRefresh),
         ];
 
         // Add media refresh timer when in media view

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -437,6 +437,11 @@ pub struct ConnectApplet {
     share_text_input: String,
     /// Timestamp of last D-Bus signal refresh (for debouncing)
     last_signal_refresh: std::time::Instant,
+    /// True when at least one D-Bus signal has been dropped by the debounce
+    /// window since the last served fetch. Cleared whenever a fetch is
+    /// dispatched. Checked when `DevicesUpdated` arrives — if set, one more
+    /// fetch is kicked to pick up state changes carried by debounced signals.
+    signal_refresh_pending: bool,
 
     // SMS state
     /// Device ID currently viewing SMS for
@@ -676,6 +681,7 @@ impl Application for ConnectApplet {
             pending_share_device: None,
             share_text_input: String::new(),
             last_signal_refresh: std::time::Instant::now(),
+            signal_refresh_pending: false,
             // SMS state
             sms_device_id: None,
             sms_device_name: None,
@@ -798,6 +804,22 @@ impl Application for ConnectApplet {
                 self.error = None;
                 self.loading = false;
                 self.status_message = None; // Clear status after refresh
+
+                // If any signals were dropped while this fetch was in flight,
+                // kick one more fetch to pick up settled state. See the
+                // signal_refresh_pending field doc for rationale.
+                if self.signal_refresh_pending {
+                    self.signal_refresh_pending = false;
+                    if let Some(conn) = &self.dbus_connection {
+                        self.last_signal_refresh = std::time::Instant::now();
+                        // [topic4-baseline] temporary: trace deferred refresh
+                        topic4_log("FLUSHED-PENDING (re-fetching after debounced signals)");
+                        return cosmic::app::Task::perform(
+                            fetch_devices_async(conn.clone()),
+                            cosmic::Action::App,
+                        );
+                    }
+                }
             }
             Message::Error(err) => {
                 tracing::error!("Error: {}", err);
@@ -1014,15 +1036,18 @@ impl Application for ConnectApplet {
                 }
             }
             Message::DbusSignalReceived => {
-                // D-Bus signal received - debounce to avoid excessive refreshes
-                // Require at least 3 seconds between signal-triggered refreshes
+                // D-Bus signal received - debounce to avoid excessive refreshes.
+                // Signals dropped by the debounce window flip a pending flag;
+                // when the in-flight fetch completes, DevicesUpdated kicks one
+                // more fetch to pick up settled state from the debounced burst.
                 let now = std::time::Instant::now();
                 let elapsed = now.duration_since(self.last_signal_refresh);
                 let debounce = std::time::Duration::from_secs(SIGNAL_REFRESH_DEBOUNCE_SECS);
                 if elapsed < debounce {
-                    // [topic4-baseline] temporary: trace dropped signals
+                    self.signal_refresh_pending = true;
+                    // [topic4-baseline] temporary: trace dropped signals (now flagged pending)
                     topic4_log(&format!(
-                        "DEBOUNCED ({}ms since last, debounce={}ms)",
+                        "DEBOUNCED+PENDING ({}ms since last, debounce={}ms)",
                         elapsed.as_millis(),
                         debounce.as_millis()
                     ));
@@ -1034,6 +1059,9 @@ impl Application for ConnectApplet {
                     // [topic4-baseline] temporary: trace served signals
                     topic4_log(&format!("SERVED ({}ms since last)", elapsed.as_millis()));
                     self.last_signal_refresh = now;
+                    // The dispatched fetch will see the latest state, so any
+                    // signal-triggered staleness up to this moment is covered.
+                    self.signal_refresh_pending = false;
                     return cosmic::app::Task::perform(
                         fetch_devices_async(conn.clone()),
                         cosmic::Action::App,

--- a/cosmic-ext-connected/src/constants.rs
+++ b/cosmic-ext-connected/src/constants.rs
@@ -11,6 +11,12 @@ pub mod dbus {
     /// Debounce interval for device refresh after D-Bus signals (seconds).
     /// Prevents rapid refreshes when multiple signals arrive in quick succession.
     pub const SIGNAL_REFRESH_DEBOUNCE_SECS: u64 = 3;
+
+    /// Tick interval for checking whether a deferred refresh is due (seconds).
+    /// When signals are dropped by the debounce window with no fetch in flight,
+    /// the pending flag has no natural wake-up. This tick polls the flag and
+    /// flushes it once the debounce window has cleared.
+    pub const PENDING_REFRESH_TICK_SECS: u64 = 1;
 }
 
 /// SMS conversation and message loading constants.

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -13,20 +13,25 @@ use zbus::Connection;
 
 // [topic4-baseline] temporary diagnostic logger. Writes to a host file
 // because the COSMIC panel applet does not surface tracing output via
-// journalctl. Remove this fn (and all callers tagged [topic4-baseline])
-// before this branch merges.
+// journalctl. PID prefix lets us filter to a single applet instance on
+// multi-monitor setups (one process per panel). Single write_all call so
+// concurrent writers from sibling instances don't interleave at the
+// syscall boundary. Remove this fn (and all callers tagged
+// [topic4-baseline]) before this branch merges.
 fn topic4_log(msg: &str) {
     use std::io::Write;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
         .unwrap_or(0);
+    let pid = std::process::id();
+    let line = format!("{} {} {}\n", pid, now_ms, msg);
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open("/tmp/cosmic-ext-connected-pair-debug.log")
     {
-        let _ = writeln!(f, "{} {}", now_ms, msg);
+        let _ = f.write_all(line.as_bytes());
     }
 }
 

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -197,6 +197,12 @@ pub fn dbus_signal_subscription() -> impl futures_util::Stream<Item = Message> {
 
                                     if is_relevant {
                                         tracing::debug!("D-Bus signal: {}.{}", interface, member);
+                                        // [topic4-baseline] temporary: trace inbound relevant signals
+                                        tracing::info!(
+                                            "[topic4-baseline] signal {}.{}",
+                                            interface,
+                                            member
+                                        );
                                         return Some((
                                             Message::DbusSignalReceived,
                                             DbusSubscriptionState::Listening { conn, stream },

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -191,23 +191,26 @@ pub fn dbus_signal_subscription() -> impl futures_util::Stream<Item = Message> {
                                         }
                                     }
 
-                                    // Only trigger refresh on specific device-related signals
+                                    // Only trigger refresh on specific device-related signals.
+                                    // Signal names match upstream KDE Connect
+                                    // (see core/daemon.h and core/device.h). The previous
+                                    // device-level names trustedChanged / pairingRequest /
+                                    // hasPairingRequestsChanged do not exist upstream — pair
+                                    // state is emitted as pairStateChanged(int).
                                     let is_relevant = match iface_str {
-                                        // Daemon signals for device discovery
+                                        // Daemon signals for device discovery and pair-state aggregate
                                         "org.kde.kdeconnect.daemon" => matches!(
                                             member_str,
                                             "deviceAdded"
                                                 | "deviceRemoved"
                                                 | "deviceVisibilityChanged"
                                                 | "announcedNameChanged"
+                                                | "pairingRequestsChanged"
                                         ),
-                                        // Device signals for pairing state
+                                        // Device signals for reachability and pair state
                                         "org.kde.kdeconnect.device" => matches!(
                                             member_str,
-                                            "reachableChanged"
-                                                | "trustedChanged"
-                                                | "pairingRequest"
-                                                | "hasPairingRequestsChanged"
+                                            "reachableChanged" | "pairStateChanged"
                                         ),
                                         // Battery and notification plugin signals
                                         "org.kde.kdeconnect.device.battery" => true,

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -11,6 +11,25 @@ use kdeconnect_dbus::plugins::{parse_sms_message, MessageType};
 use kdeconnect_dbus::DeviceProxy;
 use zbus::Connection;
 
+// [topic4-baseline] temporary diagnostic logger. Writes to a host file
+// because the COSMIC panel applet does not surface tracing output via
+// journalctl. Remove this fn (and all callers tagged [topic4-baseline])
+// before this branch merges.
+fn topic4_log(msg: &str) {
+    use std::io::Write;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/tmp/cosmic-ext-connected-pair-debug.log")
+    {
+        let _ = writeln!(f, "{} {}", now_ms, msg);
+    }
+}
+
 /// State for D-Bus signal subscription.
 #[allow(clippy::large_enum_variant)]
 enum DbusSubscriptionState {
@@ -198,11 +217,7 @@ pub fn dbus_signal_subscription() -> impl futures_util::Stream<Item = Message> {
                                     if is_relevant {
                                         tracing::debug!("D-Bus signal: {}.{}", interface, member);
                                         // [topic4-baseline] temporary: trace inbound relevant signals
-                                        tracing::info!(
-                                            "[topic4-baseline] signal {}.{}",
-                                            interface,
-                                            member
-                                        );
+                                        topic4_log(&format!("signal {}.{}", interface, member));
                                         return Some((
                                             Message::DbusSignalReceived,
                                             DbusSubscriptionState::Listening { conn, stream },

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -11,30 +11,6 @@ use kdeconnect_dbus::plugins::{parse_sms_message, MessageType};
 use kdeconnect_dbus::DeviceProxy;
 use zbus::Connection;
 
-// [topic4-baseline] temporary diagnostic logger. Writes to a host file
-// because the COSMIC panel applet does not surface tracing output via
-// journalctl. PID prefix lets us filter to a single applet instance on
-// multi-monitor setups (one process per panel). Single write_all call so
-// concurrent writers from sibling instances don't interleave at the
-// syscall boundary. Remove this fn (and all callers tagged
-// [topic4-baseline]) before this branch merges.
-fn topic4_log(msg: &str) {
-    use std::io::Write;
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
-    let pid = std::process::id();
-    let line = format!("{} {} {}\n", pid, now_ms, msg);
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open("/tmp/cosmic-ext-connected-pair-debug.log")
-    {
-        let _ = f.write_all(line.as_bytes());
-    }
-}
-
 /// State for D-Bus signal subscription.
 #[allow(clippy::large_enum_variant)]
 enum DbusSubscriptionState {
@@ -224,8 +200,6 @@ pub fn dbus_signal_subscription() -> impl futures_util::Stream<Item = Message> {
 
                                     if is_relevant {
                                         tracing::debug!("D-Bus signal: {}.{}", interface, member);
-                                        // [topic4-baseline] temporary: trace inbound relevant signals
-                                        topic4_log(&format!("signal {}.{}", interface, member));
                                         return Some((
                                             Message::DbusSignalReceived,
                                             DbusSubscriptionState::Listening { conn, stream },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Connected will be documented in this file.
 ### Fixed
 - Pair-state updates more reliable: subscribe to the correct upstream D-Bus signal names (`pairStateChanged` and daemon-level `pairingRequestsChanged`), replacing three names that did not exist in upstream KDE Connect. Pair-state was previously riding only on the `PropertiesChanged` catch-all
 - Pair-state updates no longer silently dropped during signal bursts: a follow-up refresh now fires after each signal-triggered fetch, picking up settled state even when trailing signals fall inside the 3 s debounce window
+- Pair acceptance picked up promptly when accepting on the phone right after sending the request from Connected: a 1 s tick now flushes any deferred refresh once the debounce window clears, so the UI no longer hangs on "Waiting for device to accept" until the next ambient signal
 
 ## [0.3.0] - 2026-04-14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Connected will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Pair-state updates more reliable: subscribe to the correct upstream D-Bus signal names (`pairStateChanged` and daemon-level `pairingRequestsChanged`), replacing three names that did not exist in upstream KDE Connect. Pair-state was previously riding only on the `PropertiesChanged` catch-all
+- Pair-state updates no longer silently dropped during signal bursts: a follow-up refresh now fires after each signal-triggered fetch, picking up settled state even when trailing signals fall inside the 3 s debounce window
+
 ## [0.3.0] - 2026-04-14
 
 ### Changed


### PR DESCRIPTION
## Summary

  Three fixes to KDE Connect pair-state handling on Connected's side, all
  validated with diagnostic logs captured before and after each change.

  - **Stale signal names.** `subscriptions.rs` matched three device-level
    signals that don't exist upstream (`trustedChanged`, `pairingRequest`,
    `hasPairingRequestsChanged`); pair-state was riding only on the
    `PropertiesChanged` catch-all. Replaced with upstream
    `pairStateChanged` plus daemon-level `pairingRequestsChanged`.
  - **Debounce was silently dropping trailing burst signals.** Added a
    `signal_refresh_pending` flag; when a fetch returns and the flag is
    set, one follow-up `fetch_devices_async` fires to pick up settled
    state.
  - **Pending flag had no wake-up when no fetch was in flight.** Quick
    pair-acceptance after a request burst left the UI hanging on
    "Waiting for device to accept" until the next ambient signal. Added a
    1 s tick (`Message::CheckPendingRefresh`) that flushes the flag once
    the debounce window clears. Worst-case wait now ~debounce + 1 s.

  All three are pure supersets of prior behavior. `PropertiesChanged`
  stays as belt-and-suspenders.

  ## Diagnostic commits

  Three `[topic4-baseline]` commits add a temporary file logger; the
  cleanup commit reverses them. Net code change is the three fixes only.

  ## Test plan

  - [x] Phone unpair from Connected
  - [x] Phone re-pair, phone-initiated
  - [x] Phone re-pair, Connected-initiated with quick acceptance
  - [x] Sanity install of cleaned-up build
  - [x] Build / clippy / fmt / tests clean