### PR TITLE
SMS first-open truncation fix

### DIFF
--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1821,9 +1821,25 @@ impl Application for ConnectApplet {
                     self.message_sync_active = true;
                 }
 
-                // Scroll to bottom when a sent message is confirmed;
-                // otherwise defer scroll to ConversationStoreLoaded
+                // Scroll to bottom when a sent message is confirmed.
                 if confirmed_send {
+                    return scrollable::snap_to(
+                        widget::Id::new("message-thread"),
+                        scrollable::RelativeOffset::END.into(),
+                    );
+                }
+                // While the initial load is in flight, keep the newest message
+                // in view as messages stream in. Necessary because the daemon's
+                // worker emits `conversationLoaded` only when it actually
+                // fetched fresh phone data (see daemon's
+                // `addMessages()` → `conversationLoaded`); for cached-store
+                // hits the worker just emits per-message signals and finishes
+                // silently, so `ConversationStoreLoaded` and
+                // `ConversationLoadComplete` never fire and the scroll stays
+                // pinned at the top of an oldest-first list. Bounded by
+                // `initial_load_complete` so we don't yank a user reading
+                // older messages when a new SMS arrives later.
+                if !self.initial_load_complete {
                     return scrollable::snap_to(
                         widget::Id::new("message-thread"),
                         scrollable::RelativeOffset::END.into(),

--- a/cosmic-ext-connected/src/constants.rs
+++ b/cosmic-ext-connected/src/constants.rs
@@ -52,6 +52,12 @@ pub mod sms {
     /// is emitted (initial load done) but the subscription continues listening.
     pub const PHONE_RESPONSE_TIMEOUT_MS: u64 = 8000;
 
+    /// How long to wait for the retried Conversations-interface call to settle when
+    /// the first-open phone-deadline expires with at most one local-store message
+    /// (milliseconds). The daemon writes phone-supplied messages to the local store
+    /// asynchronously, so a second read often returns the full thread.
+    pub const CONVERSATION_RETRY_WAIT_MS: u64 = 4000;
+
     /// How long to show the sync indicator on cold start (milliseconds).
     /// This is the hard ceiling for a single bootstrap attempt while loading
     /// the conversation list on cold start.

--- a/cosmic-ext-connected/src/subscriptions.rs
+++ b/cosmic-ext-connected/src/subscriptions.rs
@@ -2,7 +2,9 @@
 
 use crate::app::Message;
 use crate::constants::dbus::RETRY_DELAY_SECS;
-use crate::constants::sms::{MESSAGE_SUBSCRIPTION_TIMEOUT_SECS, PHONE_RESPONSE_TIMEOUT_MS};
+use crate::constants::sms::{
+    CONVERSATION_RETRY_WAIT_MS, MESSAGE_SUBSCRIPTION_TIMEOUT_SECS, PHONE_RESPONSE_TIMEOUT_MS,
+};
 use crate::notifications::{
     should_show_call_notification, should_show_file_notification, should_show_sms_notification,
 };
@@ -10,6 +12,32 @@ use futures_util::StreamExt;
 use kdeconnect_dbus::plugins::{parse_sms_message, MessageType};
 use kdeconnect_dbus::DeviceProxy;
 use zbus::Connection;
+
+/// Re-issue `requestConversation` on the Conversations interface as part of the
+/// first-open truncation recovery path. Offset semantics match KDE Connect's
+/// `ConversationModel::requestMoreMessages`: `start = numKnown`,
+/// `end = numKnown + howMany`. The daemon worker treats `[start, end)` as
+/// indices into the local store sorted newest-first, so this asks for the
+/// older messages we haven't seen yet.
+async fn fire_retry_request(
+    conn: &Connection,
+    device_id: &str,
+    thread_id: i64,
+    start: i32,
+    end: i32,
+) -> Result<(), String> {
+    let device_path = format!("{}/devices/{}", kdeconnect_dbus::BASE_PATH, device_id);
+    let proxy = kdeconnect_dbus::plugins::ConversationsProxy::builder(conn)
+        .path(device_path.as_str())
+        .map_err(|e| format!("path: {}", e))?
+        .build()
+        .await
+        .map_err(|e| format!("build: {}", e))?;
+    proxy
+        .request_conversation(thread_id, start, end)
+        .await
+        .map_err(|e| format!("call: {}", e))
+}
 
 /// State for D-Bus signal subscription.
 #[allow(clippy::large_enum_variant)]
@@ -561,11 +589,11 @@ enum ConversationMessageState {
         messages_per_page: u32,
     },
     Listening {
-        #[allow(dead_code)]
         conn: Connection,
         stream: zbus::MessageStream,
         thread_id: i64,
         device_id: String,
+        messages_per_page: u32,
         /// Set when `conversationLoaded` arrives; enables phone_deadline.
         local_store_done: bool,
         /// Total message count from `conversationLoaded` signal.
@@ -577,6 +605,12 @@ enum ConversationMessageState {
         /// Whether `ConversationLoadComplete` has been emitted. Once true, the subscription
         /// continues silently with a heartbeat sleep until iced drops it.
         load_complete_emitted: bool,
+        /// Count of `conversationUpdated` signals forwarded for this thread. Used to
+        /// detect the first-open truncation case (daemon's local store had only a
+        /// single message when the Conversations worker ran) at phone_deadline expiry.
+        received_message_count: usize,
+        /// Whether the one-shot Direction A retry has fired. Bounds retries to one.
+        retry_attempted: bool,
     },
     /// Terminal state - subscription is complete
     Done,
@@ -819,10 +853,13 @@ pub fn conversation_message_subscription(
                             stream,
                             thread_id,
                             device_id,
+                            messages_per_page,
                             local_store_done: false,
                             total_message_count: None,
                             phone_deadline: None,
                             load_complete_emitted: false,
+                            received_message_count: 0,
+                            retry_attempted: false,
                         },
                     ))
                 }
@@ -831,10 +868,13 @@ pub fn conversation_message_subscription(
                     mut stream,
                     thread_id,
                     device_id,
+                    messages_per_page,
                     mut local_store_done,
                     mut total_message_count,
                     mut phone_deadline,
                     mut load_complete_emitted,
+                    mut received_message_count,
+                    mut retry_attempted,
                 } => {
                     // Two-phase loading, then long-lived listening:
                     //
@@ -881,41 +921,109 @@ pub fn conversation_message_subscription(
                                         stream,
                                         thread_id,
                                         device_id,
+                                        messages_per_page,
                                         local_store_done,
                                         total_message_count,
                                         phone_deadline,
                                         load_complete_emitted,
+                                        received_message_count,
+                                        retry_attempted,
                                     },
                                 ));
                             }
                         }
 
-                        // Check phone deadline (Phase 2 → Phase 3 transition)
+                        // Check phone deadline (Phase 2 → Phase 3 transition).
+                        //
+                        // Direction A retry: if the phone deadline expires after the
+                        // local store delivered at most one message, the daemon's
+                        // first-open Conversations worker likely finished before the
+                        // phone-supplied messages were written to the local store
+                        // (see docs/SMS.md, "first-open truncation"). Re-issue
+                        // requestConversation on the Conversations interface — by now
+                        // the local store contains the phone data — and let those
+                        // signals stream through normally. Bound to one attempt.
                         if !load_complete_emitted {
                             if let Some(pd) = phone_deadline {
                                 if now >= pd {
-                                    tracing::info!(
-                                        "Subscription: phone deadline reached for thread {}, \
-                                         signaling load complete (subscription continues)",
-                                        thread_id
-                                    );
-                                    load_complete_emitted = true;
-                                    return Some((
-                                        Message::ConversationLoadComplete {
+                                    if !retry_attempted && received_message_count <= 1 {
+                                        tracing::info!(
+                                            "Subscription: thread {} truncation suspected \
+                                             ({} message(s) after phone deadline), retrying \
+                                             Conversations interface read (fallback path)",
                                             thread_id,
-                                            total_count: total_message_count.unwrap_or(0),
-                                        },
-                                        ConversationMessageState::Listening {
-                                            conn,
-                                            stream,
+                                            received_message_count
+                                        );
+                                        let start = received_message_count as i32;
+                                        let end = start + messages_per_page as i32;
+                                        match fire_retry_request(
+                                            &conn,
+                                            &device_id,
                                             thread_id,
-                                            device_id,
-                                            local_store_done,
-                                            total_message_count,
-                                            phone_deadline,
-                                            load_complete_emitted,
-                                        },
-                                    ));
+                                            start,
+                                            end,
+                                        )
+                                        .await
+                                        {
+                                            Ok(()) => {
+                                                tracing::info!(
+                                                    "Retry request_conversation fired for thread {}",
+                                                    thread_id
+                                                );
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    "Retry request_conversation failed for thread {}: {}",
+                                                    thread_id,
+                                                    e
+                                                );
+                                            }
+                                        }
+                                        retry_attempted = true;
+                                        phone_deadline = Some(
+                                            tokio::time::Instant::now()
+                                                + std::time::Duration::from_millis(
+                                                    CONVERSATION_RETRY_WAIT_MS,
+                                                ),
+                                        );
+                                        // Fall through to the select! loop so retry
+                                        // signals are received as they arrive.
+                                    } else {
+                                        if retry_attempted {
+                                            tracing::info!(
+                                                "Subscription: thread {} retry settled with {} \
+                                                 message(s); signaling load complete",
+                                                thread_id,
+                                                received_message_count
+                                            );
+                                        } else {
+                                            tracing::info!(
+                                                "Subscription: phone deadline reached for thread {}, \
+                                                 signaling load complete (subscription continues)",
+                                                thread_id
+                                            );
+                                        }
+                                        load_complete_emitted = true;
+                                        return Some((
+                                            Message::ConversationLoadComplete {
+                                                thread_id,
+                                                total_count: total_message_count.unwrap_or(0),
+                                            },
+                                            ConversationMessageState::Listening {
+                                                conn,
+                                                stream,
+                                                thread_id,
+                                                device_id,
+                                                messages_per_page,
+                                                local_store_done,
+                                                total_message_count,
+                                                phone_deadline,
+                                                load_complete_emitted,
+                                                received_message_count,
+                                                retry_attempted,
+                                            },
+                                        ));
+                                    }
                                 }
                             }
                         }
@@ -964,6 +1072,9 @@ pub fn conversation_message_subscription(
                                                                     sms_msg.uid,
                                                                     thread_id
                                                                 );
+                                                                received_message_count =
+                                                                    received_message_count
+                                                                        .saturating_add(1);
                                                                 return Some((
                                                                     Message::ConversationMessageReceived {
                                                                         thread_id,
@@ -974,10 +1085,13 @@ pub fn conversation_message_subscription(
                                                                         stream,
                                                                         thread_id,
                                                                         device_id,
+                                                                        messages_per_page,
                                                                         local_store_done,
                                                                         total_message_count,
                                                                         phone_deadline,
                                                                         load_complete_emitted,
+                                                                        received_message_count,
+                                                                        retry_attempted,
                                                                     },
                                                                 ));
                                                             }
@@ -994,18 +1108,91 @@ pub fn conversation_message_subscription(
                                                         body.deserialize::<(i64, u64)>()
                                                     {
                                                         if conv_id == thread_id {
-                                                            tracing::info!(
-                                                                "Subscription: conversationLoaded for thread {}, \
-                                                                 {} messages in store. Waiting up to {:?} for phone...",
-                                                                thread_id,
-                                                                message_count,
-                                                                phone_wait
-                                                            );
+                                                            let was_already_done =
+                                                                local_store_done;
                                                             local_store_done = true;
-                                                            total_message_count = Some(message_count);
-                                                            phone_deadline = Some(
-                                                                tokio::time::Instant::now() + phone_wait,
-                                                            );
+                                                            total_message_count =
+                                                                Some(message_count);
+                                                            if retry_attempted {
+                                                                // Retry's own conversationLoaded.
+                                                                // Don't extend phone_deadline — its
+                                                                // CONVERSATION_RETRY_WAIT_MS deadline
+                                                                // is already running.
+                                                                tracing::info!(
+                                                                    "Subscription: retry conversationLoaded for thread {}, \
+                                                                     {} messages in store",
+                                                                    thread_id,
+                                                                    message_count
+                                                                );
+                                                            } else if was_already_done
+                                                                && (message_count as usize)
+                                                                    > received_message_count
+                                                                && received_message_count
+                                                                    < messages_per_page as usize
+                                                            {
+                                                                // Option 1 trigger: the daemon
+                                                                // re-emitted conversationLoaded
+                                                                // (its `addMessages()` told us the
+                                                                // local store grew) but we got
+                                                                // fewer per-message signals than
+                                                                // the store now reports, and we
+                                                                // haven't filled a page yet — i.e.
+                                                                // a deficit in our requested
+                                                                // initial range. Covers both the
+                                                                // original "received only 1 of N"
+                                                                // truncation and the off-by-one
+                                                                // case (e.g. store=4, received=3)
+                                                                // observed for some short threads.
+                                                                // The page-size guard avoids
+                                                                // triggering on natural scroll
+                                                                // pagination boundaries.
+                                                                tracing::info!(
+                                                                    "Subscription: thread {} duplicate conversationLoaded \
+                                                                     (store={}, received={}), retrying Conversations \
+                                                                     interface read (Option 1 path)",
+                                                                    thread_id,
+                                                                    message_count,
+                                                                    received_message_count
+                                                                );
+                                                                let start =
+                                                                    received_message_count as i32;
+                                                                let end = start
+                                                                    + messages_per_page as i32;
+                                                                if let Err(e) = fire_retry_request(
+                                                                    &conn,
+                                                                    &device_id,
+                                                                    thread_id,
+                                                                    start,
+                                                                    end,
+                                                                )
+                                                                .await
+                                                                {
+                                                                    tracing::warn!(
+                                                                        "Retry request_conversation failed for thread {}: {}",
+                                                                        thread_id,
+                                                                        e
+                                                                    );
+                                                                }
+                                                                retry_attempted = true;
+                                                                phone_deadline = Some(
+                                                                    tokio::time::Instant::now()
+                                                                        + std::time::Duration::from_millis(
+                                                                            CONVERSATION_RETRY_WAIT_MS,
+                                                                        ),
+                                                                );
+                                                            } else {
+                                                                tracing::info!(
+                                                                    "Subscription: conversationLoaded for thread {}, \
+                                                                     {} messages in store. Waiting up to {:?} for phone...",
+                                                                    thread_id,
+                                                                    message_count,
+                                                                    phone_wait
+                                                                );
+                                                                phone_deadline = Some(
+                                                                    tokio::time::Instant::now()
+                                                                        + phone_wait,
+                                                                );
+                                                            }
                                                             return Some((
                                                                 Message::ConversationStoreLoaded {
                                                                     thread_id,
@@ -1016,10 +1203,13 @@ pub fn conversation_message_subscription(
                                                                     stream,
                                                                     thread_id,
                                                                     device_id,
+                                                                    messages_per_page,
                                                                     local_store_done,
                                                                     total_message_count,
                                                                     phone_deadline,
                                                                     load_complete_emitted,
+                                                                    received_message_count,
+                                                                    retry_attempted,
                                                                 },
                                                             ));
                                                         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to Connected will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Pair-state updates more reliable: subscribe to the correct upstream D-Bus signal names (`pairStateChanged` and daemon-level `pairingRequestsChanged`), replacing three names that did not exist in upstream KDE Connect. Pair-state was previously riding only on the `PropertiesChanged` catch-all
+- Pair-state updates more reliable: subscribe to the correct upstream D-Bus signal names (`pairStateChanged` and  daemon-level `pairingRequestsChanged`), replacing three names that did not exist in upstream KDE Connect.         Pair-state was previously riding only on the `PropertiesChanged` catch-all
 - Pair-state updates no longer silently dropped during signal bursts: a follow-up refresh now fires after each signal-triggered fetch, picking up settled state even when trailing signals fall inside the 3 s debounce window
 - Pair acceptance picked up promptly when accepting on the phone right after sending the request from Connected: a 1 s tick now flushes any deferred refresh once the debounce window clears, so the UI no longer hangs on "Waiting for device to accept" until the next ambient signal
+
+### Added
+- Desktop / laptop / TV peer support; "Show non-mobile devices" setting; inline share primitives on non-mobile device page; Enter-to-send on share-text inputs.
+
+### Changed
+- Accent color restricted to actionable UI; tightened device page layout; Pair/Unpair moved into the actions list; notification count rendered as a badge.
+
+### Fixed
+- SMS thread truncation on first open: re-issues requestConversation when the daemon re-emits conversationLoaded with more messages than we received, and as a fallback on phone-response timeout.
+- Message thread auto-scrolls to the newest message on open even for cached threads where the daemon doesn't emit   conversationLoaded.
 
 ## [0.3.0] - 2026-04-14
 

--- a/docs/SMS.md
+++ b/docs/SMS.md
@@ -53,9 +53,13 @@ Thread loading uses a long-lived subscription with distinct startup phases:
 
 Important details:
 
-- Initial scroll is deferred until local-store completion rather than per-message.
+- The list is rendered oldest-first, so an unscrolled scrollable lands on the oldest message. Auto-scroll-to-bottom is dispatched on `ConversationStoreLoaded`, on `ConversationLoadComplete`, on each `ConversationMessageReceived` while `!initial_load_complete`, and on confirmed sent-message echoes. The per-message dispatch covers cached-store hits where the daemon's worker satisfies the request entirely from `m_conversations` and never emits `conversationLoaded` (see `requestconversationworker.cpp`'s `numHandled >= howMany` branch), which would otherwise leave the user pinned at the top of a long thread.
 - `conversationLoaded` reflects local-store count, not authoritative phone total.
-- `initial_load_complete` gates scroll-based loading of older messages.
+- `initial_load_complete` gates scroll-based loading of older messages, and bounds the per-message auto-scroll so a new incoming SMS arriving while the user is reading older content doesn't yank them down.
+- The daemon writes phone-supplied messages to the local store asynchronously, so the first-open Conversations worker may finish before that data lands. The daemon's `addMessages()` only emits `conversationUpdated` for the latest message in a thread, so historical backfill from the phone arrives silently — observable only via a second `conversationLoaded(count)` emission with a higher count than we've received. Recovery is bounded to one re-issued `requestConversation` per thread open, with two triggers:
+  - **Primary** (Option 1): a duplicate `conversationLoaded` arrives with `store_count > received_message_count` while we're still under-filled (`received < messages_per_page`). The retry fires immediately. Catches both the original "received only 1 of N" truncation and the off-by-one "received N-1 of N" case where the daemon's worker emits one fewer per-message signal than its store reports. The page-size guard avoids firing on natural scroll-pagination boundaries.
+  - **Fallback**: `phone_deadline` expires with `received <= 1` — used if the daemon doesn't re-emit `conversationLoaded` (e.g. the phone added no new UIDs, or a signal-ordering race). Narrow gate kept here on purpose: if no duplicate fired, retry against an unchanged store would just re-deliver what we already have.
+  The retry uses `requestConversation(threadId, received, received + page)` — same offset shape as KDE Connect's `ConversationModel::requestMoreMessages`. The resulting per-message signals merge via `known_message_ids` dedup in `app.rs`.
 
 ### Older Message Loading
 
@@ -132,6 +136,7 @@ Timeout constants (see `constants.rs`):
 - `CONVERSATION_LIST_CACHE_POLL_MS` — cache re-read interval during bootstrap
 - `CONVERSATION_LIST_RETRY_THRESHOLD` / `CONVERSATION_LIST_RETRY_WAIT_MS` — cold-start retry gate and window
 - `PHONE_RESPONSE_TIMEOUT_MS` — thread phone-response window after `conversationLoaded`
+- `CONVERSATION_RETRY_WAIT_MS` — settle window for the one-shot Conversations-interface re-read fired when first-open truncation is suspected
 - `MESSAGE_SUBSCRIPTION_TIMEOUT_SECS` — Phase 1 local-store safety-net timeout
 
 D-Bus surface:


### PR DESCRIPTION
 ## Summary
  - Recover from KDE Connect daemon's "store reports more than we received" cases via a one-shot retry on duplicate  `conversationLoaded`, gated on `received < page_size` (so off-by-one Mode C cases also recover, not just the  original `received <= 1` truncation).
  - KDE-aligned `(received, received + page)` retry offset shape, matching upstream    `ConversationModel::requestMoreMessages`.
  - Phone-deadline fallback retry kept for the rarer case where the daemon doesn't re-emit `conversationLoaded`.
  - Auto-scroll thread to newest message during initial load — fixes cached-thread opens where `conversationLoaded`  never fires.

  ## Test plan
  - [x] Manual cold-start testing across multiple sessions
  - [x] Option 1 firing observed in the wild (thread 1208, store=6 received=1 → retry recovered).
  - [x] Mode B (phone-slow / network-rejoin) confirmed as a separate, out-of-scope failure class.
  - [x] `cargo build --release && cargo clippy --all-targets -- -D warnings && cargo test` all green.