### PR TITLE
Revert config version to v7

### DIFF
--- a/cosmic-ext-connected/src/config.rs
+++ b/cosmic-ext-connected/src/config.rs
@@ -8,7 +8,7 @@ pub const APP_ID: &str = "io.github.nwxnw.cosmic-ext-connected";
 
 /// Applet configuration stored in COSMIC's config system.
 #[derive(Debug, Clone, Serialize, Deserialize, CosmicConfigEntry, PartialEq, Eq)]
-#[version = 8]
+#[version = 7]
 pub struct Config {
     /// Show battery percentage in device list
     pub show_battery_percentage: bool,


### PR DESCRIPTION
 ## Summary
  - Reverts `Config` version from 8 back to 7 in `cosmic-ext-connected/src/config.rs` 
  - version bump not required for v0.4.0 because only additive config settings