### PR TITLE
v0.5.0: SMS module extraction + reaction -thread merging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,13 @@ fn is_charging(&self) -> zbus::Result<bool>;
 - To accent-color an icon widget, convert `Named` to `Icon` first, then apply `Svg::custom`:
   ```rust
   icon::from_name("icon-name").size(48).icon()
-      .class(theme::Svg::custom(|theme| svg::Style {
-          color: Some(theme.cosmic().accent_text_color().into()),
+      .class(cosmic::theme::Svg::custom(|theme| {
+          cosmic::iced::widget::svg::Style {
+              color: Some(theme.cosmic().accent_text_color().into()),
+          }
       }))
   ```
+  Note: `svg::Style` lives at `cosmic::iced::widget::svg::Style` (the consumer re-export). Reaching for `cosmic::iced_widget::svg::Style` — which is libcosmic's *internal* path — won't resolve from consumer crates.
 
 ### Code Style
 - Follow rustfmt and clippy

--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -100,6 +100,13 @@ settings-sms-notifications = Show SMS messages
 settings-sms-show-sender = Show sender
 settings-sms-show-content = Show content
 
+# SMS behavior settings
+settings-sms-merge-reaction-threads = Merge reaction-bucket threads
+settings-sms-merge-reaction-threads-desc =
+   Group iOS reactions with the conversation they're replying to. Turning this
+   off restores per-thread display but can cause some replies to be delivered
+   twice on the recipient's side.
+
 # Call Notifications settings
 settings-call-section = Calls
 settings-call-notifications = Show calls

--- a/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
+++ b/cosmic-ext-connected/i18n/en/cosmic-ext-connected.ftl
@@ -197,3 +197,7 @@ unpaired = Unpaired from device
 attachment = Attachment
 loading-attachment = Loading attachment...
 attachment-failed = Failed to load attachment
+
+# Reaction-thread merging UI
+merge-toggle-on-tooltip = Reaction threads are merged. Click to show separately.
+merge-toggle-off-tooltip = Reaction threads are shown separately. Click to merge.

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1459,7 +1459,7 @@ impl Application for ConnectApplet {
                             .appname("Connected")
                             .urgency(urgency)
                             .timeout(notify_rust::Timeout::Never);
-                        show_and_auto_close(notification, timeout_ms, "call").await;
+                        crate::notifications::show_and_auto_close(notification, timeout_ms, "call").await;
                     },
                     |_| cosmic::Action::App(Message::RefreshDevices),
                 );
@@ -1500,7 +1500,7 @@ impl Application for ConnectApplet {
                                 .icon("folder-download-symbolic")
                                 .appname("Connected")
                                 .timeout(notify_rust::Timeout::Never);
-                            show_and_auto_close(notification, timeout_ms, "file").await;
+                            crate::notifications::show_and_auto_close(notification, timeout_ms, "file").await;
                         },
                         |_| cosmic::Action::App(Message::RefreshDevices),
                     );
@@ -1734,33 +1734,3 @@ impl Application for ConnectApplet {
     }
 }
 
-/// Show a notification and auto-close it after the configured timeout.
-///
-/// COSMIC's notification daemon does not respect the `expire_timeout` hint from
-/// the freedesktop notification spec, so all notifications display for the daemon's
-/// fixed duration regardless of the value passed. To work around this, notifications
-/// are created with `Timeout::Never` (expire_timeout=0) to prevent the daemon from
-/// auto-closing them, then explicitly closed after the user's configured timeout.
-pub(crate) async fn show_and_auto_close(
-    notification: notify_rust::Notification,
-    timeout_ms: u32,
-    label: &str,
-) {
-    let label = label.to_string();
-    let result = tokio::task::spawn_blocking(move || notification.show()).await;
-    match result {
-        Ok(Ok(handle)) => {
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(timeout_ms as u64)).await;
-                // close() uses zbus::block_on internally, so run in blocking context
-                let _ = tokio::task::spawn_blocking(move || handle.close()).await;
-            });
-        }
-        Ok(Err(e)) => {
-            tracing::warn!("Failed to show {} notification: {}", label, e);
-        }
-        Err(e) => {
-            tracing::warn!("Notification task panicked: {}", e);
-        }
-    }
-}

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1615,15 +1615,21 @@ impl Application for ConnectApplet {
         let content: Element<Message> = match &self.view_mode {
             ViewMode::Settings => view_settings(&self.config),
             ViewMode::NotificationSettings => view_notification_settings(&self.config),
-            ViewMode::ConversationList => self
-                .sms
-                .view(SmsViewMode::ConversationList, self.status_message.as_deref()),
-            ViewMode::MessageThread => self
-                .sms
-                .view(SmsViewMode::MessageThread, self.status_message.as_deref()),
-            ViewMode::NewMessage => self
-                .sms
-                .view(SmsViewMode::NewMessage, self.status_message.as_deref()),
+            ViewMode::ConversationList => self.sms.view(
+                SmsViewMode::ConversationList,
+                &self.config,
+                self.status_message.as_deref(),
+            ),
+            ViewMode::MessageThread => self.sms.view(
+                SmsViewMode::MessageThread,
+                &self.config,
+                self.status_message.as_deref(),
+            ),
+            ViewMode::NewMessage => self.sms.view(
+                SmsViewMode::NewMessage,
+                &self.config,
+                self.status_message.as_deref(),
+            ),
             ViewMode::MediaControls => view_media_controls(MediaControlsParams {
                 device_name: self.media_device_name.as_deref(),
                 media_info: self.media_info.as_ref(),

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -291,6 +291,7 @@ pub enum SettingKey {
     CallShowNumber,
     CallShowName,
     FileNotifications,
+    MergeReactionThreads,
 }
 
 /// Basic device information for display.
@@ -982,6 +983,11 @@ impl Application for ConnectApplet {
                     }
                     SettingKey::FileNotifications => {
                         self.config.file_notifications = !self.config.file_notifications;
+                    }
+                    SettingKey::MergeReactionThreads => {
+                        self.config.merge_reaction_threads =
+                            !self.config.merge_reaction_threads;
+                        self.sms.rederive_conversations(&self.config);
                     }
                 }
                 tracing::debug!("Settings updated");

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1109,6 +1109,7 @@ impl Application for ConnectApplet {
                 self.sms.current_thread_id = None;
                 self.sms.current_thread_addresses = None;
                 self.sms.current_thread_sub_id = None;
+                self.sms.current_merged_thread_ids.clear();
                 self.sms.sms_loading_state = SmsLoadingState::Idle;
                 self.sms.conversation_sync_active = false;
                 self.sms.conversation_list_subscription_active = false;
@@ -1123,6 +1124,9 @@ impl Application for ConnectApplet {
                     let conversation = self.sms.conversations.iter().find(|lc| lc.primary_thread_id == thread_id);
 
                     let addresses = conversation.map(|c| c.addresses.clone());
+                    let merged_thread_ids = conversation
+                        .map(|c| c.merged_thread_ids.clone())
+                        .unwrap_or_else(|| vec![thread_id]);
 
                     // Pre-populate last_seen_sms with current time to prevent false notifications
                     // when fetching existing messages in this thread.
@@ -1137,6 +1141,7 @@ impl Application for ConnectApplet {
 
                     self.sms.current_thread_id = Some(thread_id);
                     self.sms.current_thread_addresses = addresses;
+                    self.sms.current_merged_thread_ids = merged_thread_ids;
                     self.view_mode = ViewMode::MessageThread;
 
                     // Reset pagination state
@@ -1153,7 +1158,6 @@ impl Application for ConnectApplet {
                     // The subscription will fire the D-Bus request after setting up match rules
                     self.sms.conversation_load_active = true;
                     self.sms.initial_load_complete = false;
-                    self.sms.loading_thread_id = Some(thread_id);
 
                     // Always load through daemon to ensure its cache is primed
                     // (replyToConversation requires the daemon to have loaded the conversation)
@@ -1172,6 +1176,7 @@ impl Application for ConnectApplet {
                 self.sms.current_thread_id = None;
                 self.sms.current_thread_addresses = None;
                 self.sms.current_thread_sub_id = None;
+                self.sms.current_merged_thread_ids.clear();
                 self.sms.messages.clear();
                 self.sms.sms_compose_text.clear();
                 self.sms.sms_sending = false;
@@ -1181,7 +1186,6 @@ impl Application for ConnectApplet {
                 // Clear subscription-based loading state
                 self.sms.conversation_load_active = false;
                 self.sms.initial_load_complete = false;
-                self.sms.loading_thread_id = None;
                 self.sms.known_message_ids.clear();
 
                 // Increment key to reset scroll position

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -17,8 +17,7 @@ use crate::media::{
     MediaControlsParams,
 };
 use crate::sms::{
-    conversation_list_subscription, fetch_conversations_async, fetch_older_messages_async,
-    prefetch_conversations_async, request_attachment_async, send_new_sms_async, send_sms_async,
+    conversation_list_subscription, fetch_conversations_async, prefetch_conversations_async,
     view_conversation_list, view_message_thread, view_new_message, ConversationListParams,
     MessageThreadParams, NewMessageParams, SmsConversationStore,
 };
@@ -33,16 +32,12 @@ use cosmic::app::Core;
 use cosmic::iced::core::window;
 use cosmic::iced::platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup};
 use cosmic::iced::widget::{column, scrollable};
-use cosmic::iced::{clipboard, Alignment, Subscription};
+use cosmic::iced::{Alignment, Subscription};
 use cosmic::widget;
 use cosmic::{Application, Element};
 use kdeconnect_dbus::{
     contacts::ContactLookup,
-    normalize_phone_number, phone_suffix,
-    plugins::{
-        is_address_valid, ConversationSummary, MessageType, NotificationInfo, SmsMessage,
-        OPTIMISTIC_MESSAGE_UID,
-    },
+    plugins::{ConversationSummary, NotificationInfo, SmsMessage},
 };
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -448,11 +443,6 @@ pub struct ConnectApplet {
 }
 
 impl ConnectApplet {
-    /// Check if loading more messages (pagination)
-    fn is_loading_more_messages(&self) -> bool {
-        matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
-    }
-
     /// Set a transient status message that auto-clears after 3 seconds.
     fn set_transient_status(&mut self, msg: String) -> cosmic::app::Task<Message> {
         self.status_message = Some(msg);
@@ -464,86 +454,30 @@ impl ConnectApplet {
         )
     }
 
-    /// Find the latest conversation timestamp for a phone number.
-    /// Uses suffix matching (last 10 digits) to handle format variations.
-    fn find_conversation_timestamp(&self, phone: &str) -> Option<i64> {
-        let phone_digits = normalize_phone_number(phone);
-        let target_suffix = phone_suffix(&phone_digits);
-
-        self.sms.conversations
-            .iter()
-            .filter(|conv| {
-                conv.addresses.iter().any(|addr| {
-                    let addr_digits = normalize_phone_number(addr);
-                    let addr_suffix = phone_suffix(&addr_digits);
-                    target_suffix == addr_suffix
-                })
-            })
-            .map(|conv| conv.timestamp)
-            .max()
-    }
-
-    /// Generate contact suggestions with phone numbers sorted by conversation recency.
-    /// Returns (contact_name, phone_number) tuples, limited to max_suggestions.
-    fn generate_contact_suggestions(
-        &self,
-        query: &str,
-        max_suggestions: usize,
-    ) -> Vec<(String, String)> {
-        if query.is_empty() {
-            return Vec::new();
-        }
-
-        // Search for contacts matching the query (get more to account for multi-number expansion)
-        let matching_contacts = self.sms.contacts.search_by_name(query, max_suggestions);
-
-        // Expand each contact into (name, phone, timestamp) entries
-        let mut entries: Vec<(String, String, Option<i64>)> = Vec::new();
-        for contact in matching_contacts {
-            for phone in &contact.phone_numbers {
-                let timestamp = self.find_conversation_timestamp(phone);
-                entries.push((contact.name.clone(), phone.clone(), timestamp));
+    /// Apply an `SmsReply` returned by `SmsConversationStore::update()`.
+    /// Caller batches the returned task with the store's task.
+    fn handle_sms_reply(&mut self, reply: crate::sms::SmsReply) -> cosmic::app::Task<Message> {
+        match reply {
+            crate::sms::SmsReply::ExitSms => {
+                self.view_mode = ViewMode::DevicePage;
+                cosmic::app::Task::none()
             }
+            crate::sms::SmsReply::Status(msg) => self.set_transient_status(msg),
+            crate::sms::SmsReply::SetStatus(opt) => {
+                self.status_message = opt;
+                cosmic::app::Task::none()
+            }
+            crate::sms::SmsReply::Error(e) => {
+                self.error = Some(e);
+                cosmic::app::Task::none()
+            }
+            crate::sms::SmsReply::NewMessageSent(msg) => {
+                self.status_message = Some(msg);
+                self.view_mode = ViewMode::ConversationList;
+                cosmic::app::Task::none()
+            }
+            crate::sms::SmsReply::NoOp => cosmic::app::Task::none(),
         }
-
-        // Sort by timestamp: most recent conversations first, then None (never contacted)
-        entries.sort_by(|a, b| match (&b.2, &a.2) {
-            (Some(ts_b), Some(ts_a)) => ts_b.cmp(ts_a), // Both have timestamps: recent first
-            (Some(_), None) => std::cmp::Ordering::Less, // b has timestamp, a doesn't: b first
-            (None, Some(_)) => std::cmp::Ordering::Greater, // a has timestamp, b doesn't: a first
-            (None, None) => std::cmp::Ordering::Equal,  // Neither has timestamp: keep order
-        });
-
-        // Take up to max_suggestions and drop the timestamp
-        entries
-            .into_iter()
-            .take(max_suggestions)
-            .map(|(name, phone, _)| (name, phone))
-            .collect()
-    }
-
-    /// Check if a phone number is already in the committed recipients list.
-    /// Uses suffix matching (last 10 digits) to handle format variations.
-    fn is_recipient_duplicate(&self, phone: &str) -> bool {
-        let normalized = normalize_phone_number(phone);
-        let suffix = phone_suffix(&normalized);
-        self.sms.new_message_recipients.iter().any(|(_, existing)| {
-            let existing_normalized = normalize_phone_number(existing);
-            phone_suffix(&existing_normalized) == suffix
-        })
-    }
-
-    /// Generate contact suggestions filtered to exclude already-added recipients.
-    fn generate_contact_suggestions_filtered(
-        &self,
-        query: &str,
-        max: usize,
-    ) -> Vec<(String, String)> {
-        self.generate_contact_suggestions(query, max + self.sms.new_message_recipients.len())
-            .into_iter()
-            .filter(|(_, phone)| !self.is_recipient_duplicate(phone))
-            .take(max)
-            .collect()
     }
 }
 
@@ -1267,701 +1201,17 @@ impl Application for ConnectApplet {
                 }
                 self.sms.sms_loading_state = SmsLoadingState::Idle;
             }
-            Message::ConversationsLoaded(convs) => {
-                // Slow path: full sync complete from phone (legacy batch loading)
-                tracing::info!(
-                    "Background sync complete: {} conversations (had {} cached)",
-                    convs.len(),
-                    self.sms.conversations.len()
-                );
-                // Only update if we got conversations back
-                if !convs.is_empty() {
-                    // Pre-populate last_seen_sms to prevent false notifications
-                    // for messages that already exist in loaded conversations
-                    for conv in &convs {
-                        // Only update if we don't have a newer timestamp already
-                        let current = self.sms.last_seen_sms.get(&conv.thread_id).copied();
-                        if current.is_none() || current < Some(conv.timestamp) {
-                            self.sms.last_seen_sms.insert(conv.thread_id, conv.timestamp);
-                        }
-                    }
 
-                    self.sms.conversations = convs;
-                    self.sms.conversation_list_key = self.sms.conversation_list_key.wrapping_add(1);
-                }
-                // Background sync complete - clear sync indicator
-                self.sms.conversation_sync_active = false;
-                // Reset loading state if still loading
-                if matches!(
-                    self.sms.sms_loading_state,
-                    SmsLoadingState::LoadingConversations(_)
-                ) {
-                    self.sms.sms_loading_state = SmsLoadingState::Idle;
-                }
-            }
-
-            Message::SmsPrefetchReady(device_id, conversations) => {
-                if !conversations.is_empty() {
-                    self.sms.sms_prefetch = Some((device_id, conversations));
-                }
-            }
 
             // Subscription-based conversation list loading handlers
-            Message::ConversationReceived {
-                device_id,
-                conversation,
-            } => {
-                // Guard: Only process if for current device
-                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
-                    tracing::debug!(
-                        "Ignoring conversation for device {} (current: {:?})",
-                        device_id,
-                        self.sms.sms_device_id
-                    );
-                    return cosmic::app::Task::none();
-                }
 
-                // Update or insert conversation by thread_id
-                if let Some(existing) = self
-                    .sms
-                    .conversations
-                    .iter_mut()
-                    .find(|c| c.thread_id == conversation.thread_id)
-                {
-                    // Only update if the new conversation has a newer timestamp
-                    if conversation.timestamp > existing.timestamp {
-                        *existing = conversation.clone();
-                        tracing::debug!(
-                            "Updated conversation thread {} (newer timestamp)",
-                            conversation.thread_id
-                        );
-                    }
-                } else {
-                    // Insert new conversation
-                    self.sms.conversations.push(conversation.clone());
-                    tracing::debug!("Added new conversation thread {}", conversation.thread_id);
-                }
 
-                // Re-sort by timestamp (newest first) and truncate
-                self.sms.conversations
-                    .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
-                self.sms.conversations
-                    .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
 
-                // Update last_seen for notification deduplication
-                let current = self.sms.last_seen_sms.get(&conversation.thread_id).copied();
-                if current.is_none() || current < Some(conversation.timestamp) {
-                    self.sms.last_seen_sms
-                        .insert(conversation.thread_id, conversation.timestamp);
-                }
 
-                // Transition from loading spinner to showing data (but keep sync indicator)
-                if matches!(
-                    self.sms.sms_loading_state,
-                    SmsLoadingState::LoadingConversations(_)
-                ) {
-                    self.sms.sms_loading_state = SmsLoadingState::Idle;
-                }
-            }
-            Message::ConversationSyncStarted { device_id } => {
-                // Guard: Only process if for current device
-                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
-                    return cosmic::app::Task::none();
-                }
 
-                tracing::debug!("Conversation sync started for device {}", device_id);
-                // Update loading phase to indicate we're waiting for signals
-                if matches!(
-                    self.sms.sms_loading_state,
-                    SmsLoadingState::LoadingConversations(LoadingPhase::Connecting)
-                ) {
-                    self.sms.sms_loading_state =
-                        SmsLoadingState::LoadingConversations(LoadingPhase::Requesting);
-                }
-            }
-            Message::ConversationSyncComplete { device_id } => {
-                // Guard: Only process if for current device
-                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
-                    return cosmic::app::Task::none();
-                }
-
-                tracing::info!(
-                    "Conversation sync indicator dismissed for device {}, {} conversations loaded",
-                    device_id,
-                    self.sms.conversations.len()
-                );
-
-                // Clear sync indicator only. The subscription keeps running
-                // to catch new conversations while the SMS view is open.
-                self.sms.conversation_sync_active = false;
-
-                // Only dismiss loading spinner if we have data to show.
-                // If conversations is empty, keep the spinner — the subscription
-                // continues listening and may receive conversations later.
-                // This prevents a false "no conversations" message on cold start
-                // when the phone is slow to respond.
-                if matches!(
-                    self.sms.sms_loading_state,
-                    SmsLoadingState::LoadingConversations(_)
-                ) && !self.sms.conversations.is_empty()
-                {
-                    self.sms.sms_loading_state = SmsLoadingState::Idle;
-                }
-            }
-
-            Message::ContactsLoaded(device_id, contacts) => {
-                // Only update if contacts are for the current SMS device
-                if self.sms.sms_device_id.as_ref() == Some(&device_id) {
-                    tracing::info!(
-                        "Loaded {} contacts for device {}",
-                        contacts.len(),
-                        device_id
-                    );
-                    self.sms.contacts = contacts;
-                } else {
-                    tracing::debug!(
-                        "Ignoring contacts for device {} (current: {:?})",
-                        device_id,
-                        self.sms.sms_device_id
-                    );
-                }
-            }
-            Message::LoadMoreConversations => {
-                // Show 10 more conversations (up to total available)
-                self.sms.conversations_displayed =
-                    (self.sms.conversations_displayed + 10).min(self.sms.conversations.len());
-            }
-            Message::OlderMessagesLoaded(
-                thread_id,
-                older_msgs,
-                has_more_heuristic,
-                total_count,
-            ) => {
-                // Only reset to Idle if we're currently loading more messages
-                if matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMoreMessages) {
-                    self.sms.sms_loading_state = SmsLoadingState::Idle;
-                }
-
-                if self.sms.current_thread_id == Some(thread_id) {
-                    // Filter out messages already known (safety net for signal cross-talk)
-                    let older_msgs: Vec<_> = older_msgs
-                        .into_iter()
-                        .filter(|m| !self.sms.known_message_ids.contains(&m.uid))
-                        .collect();
-                    for m in &older_msgs {
-                        self.sms.known_message_ids.insert(m.uid);
-                    }
-
-                    if !older_msgs.is_empty() {
-                        let prepended_count = older_msgs.len();
-                        tracing::info!(
-                            "Prepending {} older messages to thread {} (had {}, total: {:?})",
-                            prepended_count,
-                            thread_id,
-                            self.sms.messages.len(),
-                            total_count
-                        );
-
-                        // Prepend older messages (they come sorted oldest first)
-                        let mut combined = older_msgs;
-                        combined.append(&mut self.sms.messages);
-                        self.sms.messages = combined;
-
-                        // Update loaded count
-                        self.sms.messages_loaded_count = self.sms.messages.len() as u32;
-
-                        // Use total_count for accurate pagination if available,
-                        // otherwise fall back to heuristic
-                        self.sms.messages_has_more = match total_count {
-                            Some(total) => (self.sms.messages.len() as u64) < total,
-                            None => has_more_heuristic,
-                        };
-
-                        // Calculate scroll adjustment to preserve user's position
-                        // When we prepend messages, the content shifts down. We need to
-                        // scroll down by the estimated height of the prepended content.
-                        if let (Some(old_offset), Some(old_height)) = (
-                            self.sms.scroll_offset_before_load.take(),
-                            self.sms.content_height_before_load.take(),
-                        ) {
-                            // Estimate prepended content height (avg ~70px per message)
-                            const ESTIMATED_MSG_HEIGHT: f32 = 70.0;
-                            let prepended_height = prepended_count as f32 * ESTIMATED_MSG_HEIGHT;
-                            let new_content_height = old_height + prepended_height;
-                            let new_offset = old_offset + prepended_height;
-
-                            // Calculate relative offset (0.0 = top, 1.0 = bottom)
-                            let relative_y = (new_offset / new_content_height).clamp(0.0, 1.0);
-
-                            tracing::debug!(
-                                "Scroll adjustment: old_offset={:.1}, prepended_height={:.1}, new_relative_y={:.3}",
-                                old_offset, prepended_height, relative_y
-                            );
-
-                            return scrollable::snap_to(
-                                widget::Id::new("message-thread"),
-                                scrollable::RelativeOffset {
-                                    x: Some(0.0),
-                                    y: Some(relative_y),
-                                },
-                            );
-                        }
-                    } else {
-                        tracing::info!("No older messages returned for thread {}", thread_id);
-                        // No more messages available
-                        self.sms.messages_has_more = false;
-                        // Clear scroll state
-                        self.sms.scroll_offset_before_load = None;
-                        self.sms.content_height_before_load = None;
-                    }
-                }
-            }
-            Message::MessageThreadScrolled(viewport) => {
-                // Prefetch older messages when user scrolls near the top
-                // Trigger when within 100 pixels of the top and not already loading
-                const PREFETCH_THRESHOLD_PX: f32 = 100.0;
-
-                let scroll_offset = viewport.absolute_offset().y;
-                let content_height = viewport.content_bounds().height;
-
-                if scroll_offset < PREFETCH_THRESHOLD_PX
-                    && self.sms.messages_has_more
-                    && !self.is_loading_more_messages()
-                    && self.sms.initial_load_complete
-                    && !self.sms.messages.is_empty()
-                {
-                    tracing::debug!(
-                        "Prefetching older messages (scroll_y={:.1}px, content_height={:.1}px)",
-                        scroll_offset,
-                        content_height
-                    );
-
-                    // Store scroll state for position preservation after load
-                    self.sms.scroll_offset_before_load = Some(scroll_offset);
-                    self.sms.content_height_before_load = Some(content_height);
-
-                    // Trigger loading older messages (same logic as LoadMoreMessages)
-                    if let (Some(conn), Some(device_id), Some(thread_id)) = (
-                        &self.dbus_connection,
-                        &self.sms.sms_device_id,
-                        self.sms.current_thread_id,
-                    ) {
-                        self.sms.sms_loading_state = SmsLoadingState::LoadingMoreMessages;
-                        let start_index = self.sms.messages_loaded_count;
-                        let count = self.config.messages_per_page;
-
-                        return cosmic::app::Task::perform(
-                            fetch_older_messages_async(
-                                conn.clone(),
-                                device_id.clone(),
-                                thread_id,
-                                start_index,
-                                count,
-                            ),
-                            cosmic::Action::App,
-                        );
-                    }
-                }
-            }
-
-            Message::BubblePressStarted { uid, body } => {
-                self.sms.pressed_bubble_uid = Some(uid);
-                self.sms.pressed_bubble_body = Some(body);
-                self.sms.show_copy_hint = false;
-                // Spawn delayed task - fires after 500ms to show hint
-                return cosmic::app::Task::perform(
-                    async {
-                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                    },
-                    |_| cosmic::Action::App(Message::BubbleHintTimer),
-                );
-            }
-
-            Message::BubblePressReleased => {
-                // Clear pressed state - cancels the long-press action
-                self.sms.pressed_bubble_uid = None;
-                self.sms.pressed_bubble_body = None;
-                self.sms.show_copy_hint = false;
-            }
-
-            Message::BubbleHintTimer => {
-                // 500ms elapsed - show "Hold to copy" hint and start 1.5s timer for actual copy
-                if self.sms.pressed_bubble_uid.is_some() {
-                    self.sms.show_copy_hint = true;
-                    return cosmic::app::Task::perform(
-                        async {
-                            tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-                        },
-                        |_| cosmic::Action::App(Message::BubbleLongPressComplete),
-                    );
-                }
-            }
-
-            Message::BubbleLongPressComplete => {
-                // 2s total elapsed - copy to clipboard if still pressed
-                if let Some(body) = self.sms.pressed_bubble_body.take() {
-                    self.sms.pressed_bubble_uid = None;
-                    self.sms.show_copy_hint = false;
-                    return clipboard::write(body);
-                }
-            }
 
             // Subscription-based message loading handlers
-            Message::ConversationLoadStarted { thread_id } => {
-                // D-Bus request fired, subscription is now active
-                if self.sms.current_thread_id == Some(thread_id) {
-                    tracing::debug!(
-                        "Conversation {} load started, waiting for subscription signals",
-                        thread_id
-                    );
-                    // Update loading phase to indicate we're waiting for signals
-                    if matches!(
-                        self.sms.sms_loading_state,
-                        SmsLoadingState::LoadingMessages(LoadingPhase::Connecting)
-                    ) {
-                        self.sms.sms_loading_state =
-                            SmsLoadingState::LoadingMessages(LoadingPhase::Requesting);
-                    }
-                }
-            }
-            Message::ConversationMessageReceived { thread_id, message } => {
-                // Guard: Only process if still viewing this thread
-                if self.sms.current_thread_id != Some(thread_id) {
-                    tracing::debug!(
-                        "Ignoring message for thread {} (current: {:?})",
-                        thread_id,
-                        self.sms.current_thread_id
-                    );
-                    return cosmic::app::Task::none();
-                }
 
-                // Reconcile optimistic message: if this incoming sent message
-                // matches our optimistic insert's body within a 5-minute window,
-                // upgrade the optimistic entry in-place instead of inserting a duplicate.
-                if message.uid != OPTIMISTIC_MESSAGE_UID
-                    && message.message_type == MessageType::Sent
-                {
-                    if let Some(pos) = self.sms.messages.iter().position(|m| {
-                        m.uid == OPTIMISTIC_MESSAGE_UID
-                            && m.message_type == MessageType::Sent
-                            && m.body == message.body
-                            && (message.date - m.date).unsigned_abs() < 300_000
-                    }) {
-                        tracing::info!(
-                            "Reconciling optimistic message with real uid={}",
-                            message.uid
-                        );
-                        self.sms.messages[pos].uid = message.uid;
-                        self.sms.messages[pos].date = message.date;
-                        self.sms.known_message_ids.remove(&OPTIMISTIC_MESSAGE_UID);
-                        self.sms.known_message_ids.insert(message.uid);
-                        self.sms.sms_sending_body = None;
-                        return cosmic::app::Task::none();
-                    }
-                }
-
-                // Deduplication: skip if already have this message
-                if self.sms.known_message_ids.contains(&message.uid) {
-                    tracing::debug!(
-                        "Skipping duplicate message uid={} for thread {}",
-                        message.uid,
-                        thread_id
-                    );
-                    return cosmic::app::Task::none();
-                }
-                self.sms.known_message_ids.insert(message.uid);
-
-                // Extract sub_id from first message (for MMS group messaging)
-                if self.sms.current_thread_sub_id.is_none() {
-                    self.sms.current_thread_sub_id = Some(message.sub_id);
-                    tracing::debug!("Set sub_id to {} for thread {}", message.sub_id, thread_id);
-                }
-
-                // Check if this confirms our pending sent message
-                let confirmed_send = self.sms.sms_sending_body.is_some()
-                    && message.message_type == MessageType::Sent
-                    && self.sms.sms_sending_body.as_deref() == Some(message.body.as_str());
-                if confirmed_send {
-                    tracing::info!("Confirmed delivery of sent message uid={}", message.uid);
-                    self.sms.sms_sending_body = None;
-                }
-
-                // Insert message in sorted order by date
-                let insert_pos = self
-                    .sms
-                    .messages
-                    .iter()
-                    .position(|m| m.date > message.date)
-                    .unwrap_or(self.sms.messages.len());
-                self.sms.messages.insert(insert_pos, message);
-
-                tracing::debug!(
-                    "Added message to thread {}, now have {} messages",
-                    thread_id,
-                    self.sms.messages.len()
-                );
-
-                // Clear loading spinner after first message, show sync indicator instead
-                if matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMessages(_)) {
-                    self.sms.sms_loading_state = SmsLoadingState::Idle;
-                    self.sms.message_sync_active = true;
-                }
-
-                // Scroll to bottom when a sent message is confirmed.
-                if confirmed_send {
-                    return scrollable::snap_to(
-                        widget::Id::new("message-thread"),
-                        scrollable::RelativeOffset::END.into(),
-                    );
-                }
-                // While the initial load is in flight, keep the newest message
-                // in view as messages stream in. Necessary because the daemon's
-                // worker emits `conversationLoaded` only when it actually
-                // fetched fresh phone data (see daemon's
-                // `addMessages()` → `conversationLoaded`); for cached-store
-                // hits the worker just emits per-message signals and finishes
-                // silently, so `ConversationStoreLoaded` and
-                // `ConversationLoadComplete` never fire and the scroll stays
-                // pinned at the top of an oldest-first list. Bounded by
-                // `initial_load_complete` so we don't yank a user reading
-                // older messages when a new SMS arrives later.
-                if !self.sms.initial_load_complete {
-                    return scrollable::snap_to(
-                        widget::Id::new("message-thread"),
-                        scrollable::RelativeOffset::END.into(),
-                    );
-                }
-                return cosmic::app::Task::none();
-            }
-            Message::ConversationStoreLoaded {
-                thread_id,
-                total_count,
-            } => {
-                // Local store read complete - scroll to show messages while
-                // continuing to listen for phone response data
-                if self.sms.current_thread_id != Some(thread_id) {
-                    return cosmic::app::Task::none();
-                }
-
-                tracing::info!(
-                    "Local store loaded for thread {}: {} messages displayed, {} total in store",
-                    thread_id,
-                    self.sms.messages.len(),
-                    total_count
-                );
-
-                // Update pagination state
-                // Note: total_count from conversationLoaded reflects the LOCAL store count,
-                // which may be 0 or 1 after a reboot. Use a heuristic instead: if we've
-                // loaded a full page, there are likely more messages available.
-                self.sms.messages_loaded_count = self.sms.messages.len() as u32;
-                self.sms.messages_has_more =
-                    if total_count > 0 && (self.sms.messages.len() as u64) < total_count {
-                        true
-                    } else {
-                        self.sms.messages.len() >= self.config.messages_per_page as usize
-                    };
-
-                // Scroll to bottom to show latest messages
-                if !self.sms.messages.is_empty() {
-                    return scrollable::snap_to(
-                        widget::Id::new("message-thread"),
-                        scrollable::RelativeOffset::END.into(),
-                    );
-                }
-            }
-            Message::ConversationLoadComplete {
-                thread_id,
-                total_count,
-            } => {
-                // Guard: Only process if still viewing this thread
-                if self.sms.current_thread_id != Some(thread_id) {
-                    tracing::debug!(
-                        "Ignoring load complete for thread {} (current: {:?})",
-                        thread_id,
-                        self.sms.current_thread_id
-                    );
-                    return cosmic::app::Task::none();
-                }
-
-                tracing::info!(
-                    "Conversation {} loading complete: {} messages loaded, {} total in conversation",
-                    thread_id,
-                    self.sms.messages.len(),
-                    total_count
-                );
-
-                // Messages are already sorted during insertion, but sort again as safety
-                self.sms.messages.sort_by_key(|m| m.date);
-
-                // Update pagination state
-                // Note: total_count from conversationLoaded reflects the LOCAL store count,
-                // not the phone's total. Use a heuristic: if we've loaded a full page
-                // worth of messages, there are likely more available.
-                self.sms.messages_loaded_count = self.sms.messages.len() as u32;
-                self.sms.messages_has_more =
-                    if total_count > 0 && (self.sms.messages.len() as u64) < total_count {
-                        true
-                    } else {
-                        self.sms.messages.len() >= self.config.messages_per_page as usize
-                    };
-
-                // Update last_seen_sms with the newest message timestamp
-                if let Some(newest) = self.sms.messages.iter().map(|m| m.date).max() {
-                    let current = self.sms.last_seen_sms.get(&thread_id).copied();
-                    if current.is_none() || current < Some(newest) {
-                        self.sms.last_seen_sms.insert(thread_id, newest);
-                    }
-                }
-
-                // Clear sync indicator and loading state. The subscription keeps
-                // running to catch new messages (including sent message echoes).
-                self.sms.message_sync_active = false;
-                self.sms.initial_load_complete = true;
-                self.sms.sms_loading_state = SmsLoadingState::Idle;
-
-                // Scroll to bottom if we loaded messages
-                if !self.sms.messages.is_empty() {
-                    return scrollable::snap_to(
-                        widget::Id::new("message-thread"),
-                        scrollable::RelativeOffset::END.into(),
-                    );
-                }
-            }
-
-            Message::SmsError(err) => {
-                tracing::error!("SMS error: {}", err);
-                self.sms.sms_loading_state = SmsLoadingState::Idle;
-                // Also clear subscription state on error
-                self.sms.conversation_load_active = false;
-                self.sms.conversation_list_subscription_active = false;
-                self.sms.message_sync_active = false;
-                return self.set_transient_status(format!("SMS error: {}", err));
-            }
-            Message::SmsComposeInput(text) => {
-                self.sms.sms_compose_text = text;
-            }
-            Message::SendSms => {
-                tracing::info!("SendSms triggered");
-                tracing::info!(
-                    "State: conn={}, device_id={:?}, thread_id={:?}, text_empty={}, sending={}",
-                    self.dbus_connection.is_some(),
-                    self.sms.sms_device_id,
-                    self.sms.current_thread_id,
-                    self.sms.sms_compose_text.is_empty(),
-                    self.sms.sms_sending
-                );
-                if let (Some(conn), Some(device_id), Some(thread_id)) = (
-                    &self.dbus_connection,
-                    &self.sms.sms_device_id,
-                    self.sms.current_thread_id,
-                ) {
-                    if !self.sms.sms_compose_text.is_empty() && !self.sms.sms_sending {
-                        let message_text = self.sms.sms_compose_text.clone();
-                        self.sms.sms_sending = true;
-                        self.sms.sms_sending_body = Some(message_text.clone());
-                        tracing::info!(
-                            "Dispatching send_sms_async via replyToConversation for thread_id={}",
-                            thread_id
-                        );
-                        return cosmic::app::Task::perform(
-                            send_sms_async(
-                                conn.clone(),
-                                device_id.clone(),
-                                thread_id,
-                                message_text,
-                            ),
-                            cosmic::Action::App,
-                        );
-                    } else {
-                        tracing::warn!(
-                            "SendSms conditions not met: text_empty={}, sending={}",
-                            self.sms.sms_compose_text.is_empty(),
-                            self.sms.sms_sending
-                        );
-                    }
-                } else {
-                    tracing::warn!("SendSms missing required state");
-                }
-            }
-            Message::SmsSendResult(result) => {
-                self.sms.sms_sending = false;
-                match result {
-                    Ok(sent_body) => {
-                        tracing::info!("SMS sent successfully");
-                        self.sms.sms_compose_text.clear();
-
-                        if let Some(thread_id) = self.sms.current_thread_id {
-                            let now_ms = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_millis() as i64)
-                                .unwrap_or(0);
-
-                            // Clone before move into conversation preview
-                            let optimistic_body = sent_body.clone();
-
-                            // Update conversation list preview so it reflects the new message
-                            // when user navigates back
-                            if let Some(conv) = self
-                                .sms
-                                .conversations
-                                .iter_mut()
-                                .find(|c| c.thread_id == thread_id)
-                            {
-                                conv.last_message = sent_body;
-                                conv.timestamp = now_ms;
-                            }
-                            self.sms.conversations
-                                .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
-
-                            // Insert optimistic message if echo hasn't already arrived.
-                            // sms_sending_body is cleared by confirmed_send in
-                            // ConversationMessageReceived if the echo arrived before
-                            // SmsSendResult — skip to avoid duplicate.
-                            if self.sms.sms_sending_body.is_some() {
-                                let optimistic = SmsMessage {
-                                    body: optimistic_body,
-                                    addresses: self
-                                        .sms
-                                        .current_thread_addresses
-                                        .clone()
-                                        .unwrap_or_default(),
-                                    date: now_ms,
-                                    message_type: MessageType::Sent,
-                                    read: true,
-                                    thread_id,
-                                    uid: OPTIMISTIC_MESSAGE_UID,
-                                    sub_id: self.sms.current_thread_sub_id.unwrap_or(-1),
-                                    attachments: vec![],
-                                };
-                                self.sms.messages.push(optimistic);
-                                self.sms.known_message_ids.insert(OPTIMISTIC_MESSAGE_UID);
-                                self.sms.sms_sending_body = None;
-
-                                // No subscription restart needed — the message subscription
-                                // runs as long as the thread is open and will catch the
-                                // phone's echo naturally for optimistic reconciliation.
-
-                                return scrollable::snap_to(
-                                    widget::Id::new("message-thread"),
-                                    scrollable::RelativeOffset::END.into(),
-                                );
-                            }
-                        }
-
-                        return self.set_transient_status(fl!("sms-sent"));
-                    }
-                    Err(err) => {
-                        tracing::error!("SMS send error: {}", err);
-                        self.sms.sms_sending_body = None;
-                        return self.set_transient_status(format!(
-                            "{}: {}",
-                            fl!("sms-failed"),
-                            err
-                        ));
-                    }
-                }
-            }
             // New message
             Message::OpenNewMessage => {
                 self.view_mode = ViewMode::NewMessage;
@@ -1979,149 +1229,8 @@ impl Application for ConnectApplet {
                 self.sms.new_message_body.clear();
                 self.sms.new_message_sending = false;
             }
-            Message::NewMessageRecipientInput(text) => {
-                self.sms.contact_suggestions = self.generate_contact_suggestions_filtered(&text, 10);
-                self.sms.new_message_recipient_input = text;
-            }
-            Message::NewMessageBodyInput(text) => {
-                self.sms.new_message_body = text;
-            }
-            Message::AddManualRecipient => {
-                let input = self.sms.new_message_recipient_input.trim().to_string();
-                if is_address_valid(&input) && !self.is_recipient_duplicate(&input) {
-                    let display = self.sms.contacts.get_name_or_number(&input);
-                    self.sms.new_message_recipients.push((display, input));
-                    self.sms.new_message_recipient_input.clear();
-                    self.sms.contact_suggestions.clear();
-                    return widget::text_input::focus(widget::Id::new("new-message-recipient"));
-                }
-            }
-            Message::RemoveRecipient(index) => {
-                if index < self.sms.new_message_recipients.len() {
-                    self.sms.new_message_recipients.remove(index);
-                }
-            }
-            Message::SelectContact(_name, phone) => {
-                if !self.is_recipient_duplicate(&phone) {
-                    let display = self.sms.contacts.get_name_or_number(&phone);
-                    self.sms.new_message_recipients.push((display, phone));
-                    self.sms.new_message_recipient_input.clear();
-                    self.sms.contact_suggestions.clear();
-                    return widget::text_input::focus(widget::Id::new("new-message-recipient"));
-                }
-            }
-            Message::SendNewMessage => {
-                if let (Some(conn), Some(device_id)) = (&self.dbus_connection, &self.sms.sms_device_id)
-                {
-                    if !self.sms.new_message_recipients.is_empty()
-                        && !self.sms.new_message_body.is_empty()
-                        && !self.sms.new_message_sending
-                    {
-                        let recipients: Vec<String> = self
-                            .sms
-                            .new_message_recipients
-                            .iter()
-                            .map(|(_, phone)| phone.clone())
-                            .collect();
-                        let message = self.sms.new_message_body.clone();
-                        self.sms.new_message_sending = true;
-                        return cosmic::app::Task::perform(
-                            send_new_sms_async(
-                                conn.clone(),
-                                device_id.clone(),
-                                recipients,
-                                message,
-                            ),
-                            cosmic::Action::App,
-                        );
-                    }
-                }
-            }
-            Message::NewMessageSendResult(result) => {
-                self.sms.new_message_sending = false;
-                match &result {
-                    Ok(msg) => {
-                        tracing::info!("New message send result: {}", msg);
-                        self.status_message = Some(msg.clone());
-                        // Clear fields and return to conversation list
-                        self.sms.new_message_recipients.clear();
-                        self.sms.new_message_recipient_input.clear();
-                        self.sms.new_message_body.clear();
-                        self.view_mode = ViewMode::ConversationList;
-                        // Enable subscription to catch the new conversation when the phone
-                        // syncs back. The subscription listens over a longer window than a
-                        // one-shot fetch, giving the phone time to process the send and
-                        // emit a conversationCreated signal.
-                        if self.sms.sms_device_id.is_some() {
-                            self.sms.conversation_list_subscription_active = true;
-                            self.sms.conversation_sync_active = true;
-                        }
-                    }
-                    Err(err) => {
-                        tracing::error!("New message send error: {}", err);
-                        return self.set_transient_status(format!("Send failed: {}", err));
-                    }
-                }
-            }
 
             // Attachment messages
-            Message::OpenAttachment {
-                device_id,
-                device_name,
-                part_id,
-                unique_identifier,
-            } => {
-                // Check if KDE Connect has already cached this attachment
-                // KDE Connect daemon caches to ~/.cache/kdeconnect.daemon/<device-name>/
-                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-                let cache_dir = std::path::PathBuf::from(home)
-                    .join(".cache/kdeconnect.daemon")
-                    .join(&device_name);
-                let cached_path = cache_dir.join(&unique_identifier);
-
-                if cached_path.exists() {
-                    // Already cached — open immediately
-                    let path_str = cached_path.to_string_lossy().to_string();
-                    return cosmic::app::Task::perform(
-                        async move {
-                            let _ = tokio::process::Command::new("xdg-open")
-                                .arg(&path_str)
-                                .spawn();
-                        },
-                        |_| cosmic::Action::App(Message::ClearStatusMessage),
-                    );
-                }
-
-                // Not cached — request from phone via D-Bus
-                if let Some(conn) = &self.dbus_connection {
-                    self.status_message = Some(fl!("loading-attachment"));
-                    return cosmic::app::Task::perform(
-                        request_attachment_async(
-                            conn.clone(),
-                            device_id,
-                            device_name,
-                            part_id,
-                            unique_identifier,
-                        ),
-                        cosmic::Action::App,
-                    );
-                }
-            }
-            Message::AttachmentReady(file_path) => {
-                self.status_message = None;
-                return cosmic::app::Task::perform(
-                    async move {
-                        let _ = tokio::process::Command::new("xdg-open")
-                            .arg(&file_path)
-                            .spawn();
-                    },
-                    |_| cosmic::Action::App(Message::ClearStatusMessage),
-                );
-            }
-            Message::AttachmentError(err) => {
-                tracing::error!("Attachment error: {}", err);
-                return self.set_transient_status(fl!("attachment-failed"));
-            }
 
             // Media control messages
             Message::OpenMediaView(device_id) => {
@@ -2291,86 +1400,6 @@ impl Application for ConnectApplet {
             }
 
             // SMS Notifications
-            Message::SmsNotificationReceived(device_id, message) => {
-                // Freshness check: only notify for messages received within the last 30 seconds.
-                // This prevents false notifications when fetching historical messages and handles
-                // cross-process deduplication (COSMIC spawns multiple applet instances).
-                let now_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map(|d| d.as_millis() as i64)
-                    .unwrap_or(0);
-                let message_age_ms = now_ms - message.date;
-                if message_age_ms > 30_000 {
-                    // Message is older than 30 seconds, skip notification
-                    return cosmic::app::Task::none();
-                }
-
-                // Check if we've already seen this message (deduplication)
-                let last_seen = self.sms.last_seen_sms.get(&message.thread_id).copied();
-                if last_seen.is_some() && last_seen >= Some(message.date) {
-                    // Already seen this message or an older one
-                    return cosmic::app::Task::none();
-                }
-
-                // Update last seen timestamp for this thread
-                self.sms.last_seen_sms.insert(message.thread_id, message.date);
-
-                // Capture config settings
-                let show_sender = self.config.sms_notification_show_sender;
-                let show_content = self.config.sms_notification_show_content;
-                let timeout_ms = self.config.notification_timeout_secs * 1000;
-                let message_body = message.body.clone();
-
-                // Resolve sender name: use cached contacts if available, otherwise load from disk
-                let cached_sender_name = if show_sender {
-                    let has_cached_contacts = self.sms.sms_device_id.as_ref() == Some(&device_id)
-                        && !self.sms.contacts.is_empty();
-                    if has_cached_contacts {
-                        Some(self.sms.contacts.get_group_display_name(&message.addresses, 3))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
-                let addresses = message.addresses.clone();
-
-                // Show notification asynchronously
-                return cosmic::app::Task::perform(
-                    async move {
-                        // Build summary: resolve sender name if needed and not already cached
-                        let summary = if show_sender {
-                            let sender_name = match cached_sender_name {
-                                Some(name) => name,
-                                None => {
-                                    let contacts = ContactLookup::load_for_device(&device_id).await;
-                                    contacts.get_group_display_name(&addresses, 3)
-                                }
-                            };
-                            fl!("sms-notification-title-from", sender = sender_name)
-                        } else {
-                            fl!("sms-notification-title")
-                        };
-
-                        let body = if show_content {
-                            message_body
-                        } else {
-                            fl!("sms-notification-body-hidden")
-                        };
-
-                        let mut notification = notify_rust::Notification::new();
-                        notification
-                            .summary(&summary)
-                            .body(&body)
-                            .icon("phone-symbolic")
-                            .appname("Connected")
-                            .timeout(notify_rust::Timeout::Never);
-                        show_and_auto_close(notification, timeout_ms, "SMS").await;
-                    },
-                    |_| cosmic::Action::App(Message::RefreshDevices),
-                );
-            }
 
             // Call Notifications
             Message::CallNotification {
@@ -2479,6 +1508,52 @@ impl Application for ConnectApplet {
                         |_| cosmic::Action::App(Message::RefreshDevices),
                     );
                 }
+            }
+
+            // Delegate SMS state-machine arms to SmsConversationStore.
+            // The 6 SMS lifecycle arms (OpenSmsView, CloseSmsView, OpenConversation,
+            // CloseConversation, OpenNewMessage, CloseNewMessage) stay inline above
+            // because they touch view_mode (app-owned).
+            Message::SmsPrefetchReady(_, _)
+            | Message::ConversationsLoaded(_)
+            | Message::ContactsLoaded(_, _)
+            | Message::ConversationReceived { .. }
+            | Message::ConversationSyncStarted { .. }
+            | Message::ConversationSyncComplete { .. }
+            | Message::LoadMoreConversations
+            | Message::OlderMessagesLoaded(..)
+            | Message::MessageThreadScrolled(_)
+            | Message::BubblePressStarted { .. }
+            | Message::BubblePressReleased
+            | Message::BubbleHintTimer
+            | Message::BubbleLongPressComplete
+            | Message::ConversationLoadStarted { .. }
+            | Message::ConversationMessageReceived { .. }
+            | Message::ConversationStoreLoaded { .. }
+            | Message::ConversationLoadComplete { .. }
+            | Message::SmsError(_)
+            | Message::SmsComposeInput(_)
+            | Message::SendSms
+            | Message::SmsSendResult(_)
+            | Message::NewMessageRecipientInput(_)
+            | Message::NewMessageBodyInput(_)
+            | Message::AddManualRecipient
+            | Message::RemoveRecipient(_)
+            | Message::SelectContact(_, _)
+            | Message::SendNewMessage
+            | Message::NewMessageSendResult(_)
+            | Message::OpenAttachment { .. }
+            | Message::AttachmentReady(_)
+            | Message::AttachmentError(_)
+            | Message::SmsNotificationReceived(_, _) => {
+                let ctx = crate::sms::SmsCtx {
+                    conn: self.dbus_connection.as_ref(),
+                    config: &self.config,
+                    devices: &self.devices,
+                };
+                let (sms_task, reply) = self.sms.update(message, &ctx);
+                let reply_task = self.handle_sms_reply(reply);
+                return cosmic::app::Task::batch([sms_task, reply_task]);
             }
         }
 
@@ -2736,7 +1811,7 @@ impl Application for ConnectApplet {
 /// fixed duration regardless of the value passed. To work around this, notifications
 /// are created with `Timeout::Never` (expire_timeout=0) to prevent the daemon from
 /// auto-closing them, then explicitly closed after the user's configured timeout.
-async fn show_and_auto_close(
+pub(crate) async fn show_and_auto_close(
     notification: notify_rust::Notification,
     timeout_ms: u32,
     label: &str,

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1067,7 +1067,10 @@ impl Application for ConnectApplet {
                                     self.sms.last_seen_sms.insert(conv.thread_id, conv.timestamp);
                                 }
                             }
-                            self.sms.conversations = prefetched;
+                            self.sms.conversations = prefetched
+                                .into_iter()
+                                .map(crate::sms::logical::LogicalConversation::from_single)
+                                .collect();
                             self.sms.conversations_displayed = 10;
                             self.sms.sms_loading_state = SmsLoadingState::Idle;
                             self.sms.conversation_sync_active = true;
@@ -1117,7 +1120,7 @@ impl Application for ConnectApplet {
                 // Guard: need D-Bus connection and device ID for the subscription
                 if self.dbus_connection.is_some() && self.sms.sms_device_id.is_some() {
                     // Find the conversation for header info and deduplication
-                    let conversation = self.sms.conversations.iter().find(|c| c.thread_id == thread_id);
+                    let conversation = self.sms.conversations.iter().find(|lc| lc.primary_thread_id == thread_id);
 
                     let addresses = conversation.map(|c| c.addresses.clone());
 

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -17,13 +17,10 @@ use crate::media::{
     MediaControlsParams,
 };
 use crate::sms::{
-    conversation_list_subscription, fetch_conversations_async, prefetch_conversations_async,
-    view_conversation_list, view_message_thread, view_new_message, ConversationListParams,
-    MessageThreadParams, NewMessageParams, SmsConversationStore,
+    fetch_conversations_async, prefetch_conversations_async, SmsConversationStore, SmsViewMode,
 };
 use crate::subscriptions::{
-    call_notification_subscription, conversation_message_subscription, dbus_signal_subscription,
-    sms_notification_subscription,
+    call_notification_subscription, dbus_signal_subscription, sms_notification_subscription,
 };
 use crate::ui;
 use crate::views::send_to::{view_send_to, view_share_text, SendToParams, ShareTextParams};
@@ -1607,48 +1604,15 @@ impl Application for ConnectApplet {
         let content: Element<Message> = match &self.view_mode {
             ViewMode::Settings => view_settings(&self.config),
             ViewMode::NotificationSettings => view_notification_settings(&self.config),
-            ViewMode::ConversationList => view_conversation_list(ConversationListParams {
-                device_name: self.sms.sms_device_name.as_deref(),
-                conversations: &self.sms.conversations,
-                conversations_displayed: self.sms.conversations_displayed,
-                contacts: &self.sms.contacts,
-                loading_state: &self.sms.sms_loading_state,
-                sync_active: self.sms.conversation_sync_active,
-            }),
-            ViewMode::MessageThread => {
-                let thread = view_message_thread(MessageThreadParams {
-                    device_id: self.sms.sms_device_id.as_deref().unwrap_or(""),
-                    device_name: self.sms.sms_device_name.as_deref().unwrap_or(""),
-                    thread_addresses: self.sms.current_thread_addresses.as_deref(),
-                    messages: &self.sms.messages,
-                    contacts: &self.sms.contacts,
-                    loading_state: &self.sms.sms_loading_state,
-                    sms_compose_text: &self.sms.sms_compose_text,
-                    sms_sending: self.sms.sms_sending,
-                    sync_active: self.sms.message_sync_active,
-                    pressed_bubble_uid: self.sms.pressed_bubble_uid,
-                    show_copy_hint: self.sms.show_copy_hint,
-                    status_message: self.status_message.as_deref(),
-                });
-                // popup_container uses Shrink height internally, which sets a
-                // compression flag on iced's layout limits. Under compression,
-                // the flex layout processes all children in document order and a
-                // scrollable's intrinsic content size consumes all available
-                // height, leaving 0 for the compose row below it. A Fixed height
-                // wrapper is the only way to clear that flag (Fill doesn't);
-                // the value is capped to popup_container's 1000px max.
-                widget::container(thread)
-                    .height(cosmic::iced::Length::Fixed(10_000.0))
-                    .width(cosmic::iced::Length::Fill)
-                    .into()
-            }
-            ViewMode::NewMessage => view_new_message(NewMessageParams {
-                recipients: &self.sms.new_message_recipients,
-                recipient_input: &self.sms.new_message_recipient_input,
-                body: &self.sms.new_message_body,
-                sending: self.sms.new_message_sending,
-                contact_suggestions: &self.sms.contact_suggestions,
-            }),
+            ViewMode::ConversationList => self
+                .sms
+                .view(SmsViewMode::ConversationList, self.status_message.as_deref()),
+            ViewMode::MessageThread => self
+                .sms
+                .view(SmsViewMode::MessageThread, self.status_message.as_deref()),
+            ViewMode::NewMessage => self
+                .sms
+                .view(SmsViewMode::NewMessage, self.status_message.as_deref()),
             ViewMode::MediaControls => view_media_controls(MediaControlsParams {
                 device_name: self.media_device_name.as_deref(),
                 media_info: self.media_info.as_ref(),
@@ -1756,42 +1720,8 @@ impl Application for ConnectApplet {
             subscriptions.push(Subscription::run(call_notification_subscription));
         }
 
-        // Add conversation list subscription for incremental loading
-        // This provides real-time UI updates as conversations arrive from the phone
-        if self.sms.conversation_list_subscription_active {
-            if let Some(device_id) = self.sms.sms_device_id.clone() {
-                subscriptions.push(Subscription::run_with(
-                    ("conversation_list", device_id.clone()),
-                    |(_, device_id)| conversation_list_subscription(device_id.clone()),
-                ));
-            }
-        }
-
-        // Add conversation message subscription when loading a conversation
-        // This provides incremental message loading via D-Bus signals
-        // The subscription fires the D-Bus request itself after setting up match rules
-        if self.sms.conversation_load_active {
-            if let (Some(thread_id), Some(device_id)) =
-                (self.sms.loading_thread_id, self.sms.sms_device_id.clone())
-            {
-                let messages_per_page = self.config.messages_per_page;
-                subscriptions.push(Subscription::run_with(
-                    (
-                        "conversation_messages",
-                        thread_id,
-                        device_id.clone(),
-                        messages_per_page,
-                    ),
-                    |(_, thread_id, device_id, messages_per_page)| {
-                        conversation_message_subscription(
-                            *thread_id,
-                            device_id.clone(),
-                            *messages_per_page,
-                        )
-                    },
-                ));
-            }
-        }
+        // SMS-state-driven subscriptions (conversation list + per-thread messages)
+        subscriptions.extend(self.sms.subscriptions(&self.config));
 
         // Note: File notifications are handled in the main dbus_signal_subscription
         // to avoid issues with multiple D-Bus connections and match rules

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -20,7 +20,7 @@ use crate::sms::{
     conversation_list_subscription, fetch_conversations_async, fetch_older_messages_async,
     prefetch_conversations_async, request_attachment_async, send_new_sms_async, send_sms_async,
     view_conversation_list, view_message_thread, view_new_message, ConversationListParams,
-    MessageThreadParams, NewMessageParams,
+    MessageThreadParams, NewMessageParams, SmsConversationStore,
 };
 use crate::subscriptions::{
     call_notification_subscription, conversation_message_subscription, dbus_signal_subscription,
@@ -44,7 +44,6 @@ use kdeconnect_dbus::{
         OPTIMISTIC_MESSAGE_UID,
     },
 };
-use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -423,74 +422,7 @@ pub struct ConnectApplet {
     signal_refresh_pending: bool,
 
     // SMS state
-    /// Device ID currently viewing SMS for
-    sms_device_id: Option<String>,
-    /// Device name for SMS view header
-    sms_device_name: Option<String>,
-    /// List of conversations for current device
-    conversations: Vec<ConversationSummary>,
-    /// Prefetched conversations from device selection, consumed by OpenSmsView
-    sms_prefetch: Option<(String, Vec<ConversationSummary>)>,
-    /// Whether background sync is active (syncing more conversations from phone)
-    conversation_sync_active: bool,
-    /// Whether subscription-based conversation list loading is active
-    conversation_list_subscription_active: bool,
-    /// Whether background sync is active for messages in current thread
-    message_sync_active: bool,
-    /// Whether subscription-based conversation loading is active
-    conversation_load_active: bool,
-    /// Whether the initial message load is complete (local store + phone response).
-    /// Used to gate scroll prefetch — prefetch must wait until the initial
-    /// subscription load finishes to avoid collecting duplicate D-Bus signals.
-    initial_load_complete: bool,
-    /// Thread ID currently being loaded via subscription (for filtering signals)
-    loading_thread_id: Option<i64>,
-    /// Set of message UIDs already displayed (for deduplication during incremental loading)
-    known_message_ids: HashSet<i32>,
-    /// Current conversation thread ID being viewed
-    current_thread_id: Option<i64>,
-    /// Current conversation addresses (all participants, for sending and header)
-    current_thread_addresses: Option<Vec<String>>,
-    /// Current conversation's SIM subscription ID (for MMS group messages)
-    current_thread_sub_id: Option<i64>,
-    /// Messages in the current thread
-    messages: Vec<SmsMessage>,
-    /// SMS loading state with phase tracking
-    sms_loading_state: SmsLoadingState,
-    /// Contact lookup for resolving phone numbers to names
-    contacts: ContactLookup,
-    /// Key to reset conversation list scroll position
-    conversation_list_key: u32,
-    /// Number of conversations currently displayed (for pagination)
-    conversations_displayed: usize,
-    /// Text input for composing SMS reply
-    sms_compose_text: String,
-    /// Whether SMS is currently being sent
-    sms_sending: bool,
-    /// Body text of message being sent (for matching confirmed delivery signal)
-    sms_sending_body: Option<String>,
-
-    // Message pagination state
-    /// Number of messages currently loaded for pagination offset
-    messages_loaded_count: u32,
-    /// Whether more older messages are available
-    messages_has_more: bool,
-    /// Scroll offset before loading older messages (for position preservation)
-    scroll_offset_before_load: Option<f32>,
-    /// Content height before loading older messages (for position preservation)
-    content_height_before_load: Option<f32>,
-
-    // New message compose state
-    /// Committed recipient chips: (display_name, phone_number)
-    new_message_recipients: Vec<(String, String)>,
-    /// Current text in the recipient input field
-    new_message_recipient_input: String,
-    /// Body input for new message
-    new_message_body: String,
-    /// Whether new message is being sent
-    new_message_sending: bool,
-    /// Contact suggestions for new message: (contact_name, phone_number)
-    contact_suggestions: Vec<(String, String)>,
+    sms: SmsConversationStore,
 
     // Media controls state
     /// Device ID for media controls view
@@ -510,27 +442,15 @@ pub struct ConnectApplet {
     /// Device type for SendTo view header (e.g., "phone", "tablet")
     sendto_device_type: Option<String>,
 
-    // SMS notification deduplication
-    /// Last seen SMS timestamp per thread_id to avoid duplicate notifications
-    last_seen_sms: HashMap<i64, i64>,
-
     // File notification deduplication
     /// Last received file URL to avoid duplicate notifications
     last_received_file: Option<String>,
-
-    // Long-press copy state
-    /// UID of message bubble currently being pressed (for long-press detection)
-    pressed_bubble_uid: Option<i32>,
-    /// Body text of message being pressed (to copy on long-press)
-    pressed_bubble_body: Option<String>,
-    /// Whether to show the "Hold to copy" hint (500ms elapsed, waiting for 2s)
-    show_copy_hint: bool,
 }
 
 impl ConnectApplet {
     /// Check if loading more messages (pagination)
     fn is_loading_more_messages(&self) -> bool {
-        matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
+        matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
     }
 
     /// Set a transient status message that auto-clears after 3 seconds.
@@ -550,7 +470,7 @@ impl ConnectApplet {
         let phone_digits = normalize_phone_number(phone);
         let target_suffix = phone_suffix(&phone_digits);
 
-        self.conversations
+        self.sms.conversations
             .iter()
             .filter(|conv| {
                 conv.addresses.iter().any(|addr| {
@@ -575,7 +495,7 @@ impl ConnectApplet {
         }
 
         // Search for contacts matching the query (get more to account for multi-number expansion)
-        let matching_contacts = self.contacts.search_by_name(query, max_suggestions);
+        let matching_contacts = self.sms.contacts.search_by_name(query, max_suggestions);
 
         // Expand each contact into (name, phone, timestamp) entries
         let mut entries: Vec<(String, String, Option<i64>)> = Vec::new();
@@ -607,7 +527,7 @@ impl ConnectApplet {
     fn is_recipient_duplicate(&self, phone: &str) -> bool {
         let normalized = normalize_phone_number(phone);
         let suffix = phone_suffix(&normalized);
-        self.new_message_recipients.iter().any(|(_, existing)| {
+        self.sms.new_message_recipients.iter().any(|(_, existing)| {
             let existing_normalized = normalize_phone_number(existing);
             phone_suffix(&existing_normalized) == suffix
         })
@@ -619,7 +539,7 @@ impl ConnectApplet {
         query: &str,
         max: usize,
     ) -> Vec<(String, String)> {
-        self.generate_contact_suggestions(query, max + self.new_message_recipients.len())
+        self.generate_contact_suggestions(query, max + self.sms.new_message_recipients.len())
             .into_iter()
             .filter(|(_, phone)| !self.is_recipient_duplicate(phone))
             .take(max)
@@ -662,39 +582,7 @@ impl Application for ConnectApplet {
             last_signal_refresh: std::time::Instant::now(),
             signal_refresh_pending: false,
             // SMS state
-            sms_device_id: None,
-            sms_device_name: None,
-            conversations: Vec::new(),
-            sms_prefetch: None,
-            conversation_sync_active: false,
-            conversation_list_subscription_active: false,
-            message_sync_active: false,
-            conversation_load_active: false,
-            initial_load_complete: false,
-            loading_thread_id: None,
-            known_message_ids: HashSet::new(),
-            current_thread_id: None,
-            current_thread_addresses: None,
-            current_thread_sub_id: None,
-            messages: Vec::new(),
-            sms_loading_state: SmsLoadingState::Idle,
-            contacts: ContactLookup::default(),
-            conversation_list_key: 0,
-            conversations_displayed: 10,
-            sms_compose_text: String::new(),
-            sms_sending: false,
-            sms_sending_body: None,
-            // Message pagination state
-            messages_loaded_count: 0,
-            messages_has_more: true,
-            scroll_offset_before_load: None,
-            content_height_before_load: None,
-            // New message state
-            new_message_recipients: Vec::new(),
-            new_message_recipient_input: String::new(),
-            new_message_body: String::new(),
-            new_message_sending: false,
-            contact_suggestions: Vec::new(),
+            sms: SmsConversationStore::new(),
             // Media controls state
             media_device_id: None,
             media_device_name: None,
@@ -704,14 +592,8 @@ impl Application for ConnectApplet {
             // SendTo state
             sendto_device_id: None,
             sendto_device_type: None,
-            // SMS notification deduplication
-            last_seen_sms: HashMap::new(),
             // File notification deduplication
             last_received_file: None,
-            // Long-press copy state
-            pressed_bubble_uid: None,
-            pressed_bubble_body: None,
-            show_copy_hint: false,
         };
 
         // Connect to D-Bus on startup
@@ -825,7 +707,7 @@ impl Application for ConnectApplet {
                 self.selected_device = None;
                 self.view_mode = ViewMode::DeviceList;
                 self.share_text_input.clear();
-                self.sms_prefetch = None;
+                self.sms.sms_prefetch = None;
             }
             Message::OpenSendToView(device_id, device_type) => {
                 self.sendto_device_id = Some(device_id);
@@ -1197,20 +1079,20 @@ impl Application for ConnectApplet {
                         .map(|d| d.name.clone());
 
                     // Check if we have cached conversations for this device
-                    let same_device = self.sms_device_id.as_ref() == Some(&device_id);
-                    let has_cache = same_device && !self.conversations.is_empty();
+                    let same_device = self.sms.sms_device_id.as_ref() == Some(&device_id);
+                    let has_cache = same_device && !self.sms.conversations.is_empty();
 
                     self.view_mode = ViewMode::ConversationList;
-                    self.sms_device_id = Some(device_id.clone());
-                    self.sms_device_name = device_name;
+                    self.sms.sms_device_id = Some(device_id.clone());
+                    self.sms.sms_device_name = device_name;
 
                     // Clear contacts if switching to a different device
                     if !same_device {
-                        self.contacts = ContactLookup::default();
+                        self.sms.contacts = ContactLookup::default();
                     }
 
                     // Load contacts if not already loaded for this device
-                    let needs_contacts = self.contacts.is_empty();
+                    let needs_contacts = self.sms.contacts.is_empty();
                     let contacts_task = if needs_contacts {
                         let device_id_for_contacts = device_id.clone();
                         cosmic::app::Task::perform(
@@ -1227,40 +1109,41 @@ impl Application for ConnectApplet {
 
                     // Check if we have prefetched conversations for this device
                     let has_prefetch = self
+                        .sms
                         .sms_prefetch
                         .as_ref()
                         .is_some_and(|(id, convs)| id == &device_id && !convs.is_empty());
 
                     if has_cache {
                         // Use in-memory cached conversations, enable subscription for background refresh
-                        self.sms_loading_state = SmsLoadingState::Idle; // Show cached data immediately
-                        self.conversation_sync_active = true; // Show sync indicator
-                        self.conversation_list_subscription_active = true; // Enable subscription
+                        self.sms.sms_loading_state = SmsLoadingState::Idle; // Show cached data immediately
+                        self.sms.conversation_sync_active = true; // Show sync indicator
+                        self.sms.conversation_list_subscription_active = true; // Enable subscription
                         tracing::info!(
                             "Using cached {} conversations for device: {}, starting subscription-based sync",
-                            self.conversations.len(),
+                            self.sms.conversations.len(),
                             device_id
                         );
                         // Subscription will handle background sync
                         return contacts_task;
                     } else if has_prefetch {
                         // Use prefetched conversations from device selection
-                        if let Some((_, prefetched)) = self.sms_prefetch.take() {
+                        if let Some((_, prefetched)) = self.sms.sms_prefetch.take() {
                             // Seed last_seen_sms to prevent false notifications
                             for conv in &prefetched {
-                                let current = self.last_seen_sms.get(&conv.thread_id).copied();
+                                let current = self.sms.last_seen_sms.get(&conv.thread_id).copied();
                                 if current.is_none() || current < Some(conv.timestamp) {
-                                    self.last_seen_sms.insert(conv.thread_id, conv.timestamp);
+                                    self.sms.last_seen_sms.insert(conv.thread_id, conv.timestamp);
                                 }
                             }
-                            self.conversations = prefetched;
-                            self.conversations_displayed = 10;
-                            self.sms_loading_state = SmsLoadingState::Idle;
-                            self.conversation_sync_active = true;
-                            self.conversation_list_subscription_active = true;
+                            self.sms.conversations = prefetched;
+                            self.sms.conversations_displayed = 10;
+                            self.sms.sms_loading_state = SmsLoadingState::Idle;
+                            self.sms.conversation_sync_active = true;
+                            self.sms.conversation_list_subscription_active = true;
                             tracing::info!(
                                 "Using prefetched {} conversations for device: {}, starting subscription-based sync",
-                                self.conversations.len(),
+                                self.sms.conversations.len(),
                                 device_id
                             );
                         }
@@ -1268,12 +1151,12 @@ impl Application for ConnectApplet {
                     } else {
                         // No cache or different device - subscription-based loading
                         // Conversations will arrive incrementally via signals
-                        self.sms_loading_state =
+                        self.sms.sms_loading_state =
                             SmsLoadingState::LoadingConversations(LoadingPhase::Connecting);
-                        self.conversation_sync_active = true;
-                        self.conversation_list_subscription_active = true; // Enable subscription
-                        self.conversations.clear();
-                        self.conversations_displayed = 10;
+                        self.sms.conversation_sync_active = true;
+                        self.sms.conversation_list_subscription_active = true; // Enable subscription
+                        self.sms.conversations.clear();
+                        self.sms.conversations_displayed = 10;
                         tracing::info!(
                             "Opening SMS view for device: {} (subscription-based loading)",
                             device_id
@@ -1288,22 +1171,22 @@ impl Application for ConnectApplet {
                 self.view_mode = ViewMode::DevicePage;
                 // Keep sms_device_id, sms_device_name, conversations, contacts
                 // for when user returns to SMS view
-                self.messages.clear();
-                self.current_thread_id = None;
-                self.current_thread_addresses = None;
-                self.current_thread_sub_id = None;
-                self.sms_loading_state = SmsLoadingState::Idle;
-                self.conversation_sync_active = false;
-                self.conversation_list_subscription_active = false;
-                self.sms_compose_text.clear();
-                self.sms_sending = false;
-                self.sms_sending_body = None;
+                self.sms.messages.clear();
+                self.sms.current_thread_id = None;
+                self.sms.current_thread_addresses = None;
+                self.sms.current_thread_sub_id = None;
+                self.sms.sms_loading_state = SmsLoadingState::Idle;
+                self.sms.conversation_sync_active = false;
+                self.sms.conversation_list_subscription_active = false;
+                self.sms.sms_compose_text.clear();
+                self.sms.sms_sending = false;
+                self.sms.sms_sending_body = None;
             }
             Message::OpenConversation(thread_id) => {
                 // Guard: need D-Bus connection and device ID for the subscription
-                if self.dbus_connection.is_some() && self.sms_device_id.is_some() {
+                if self.dbus_connection.is_some() && self.sms.sms_device_id.is_some() {
                     // Find the conversation for header info and deduplication
-                    let conversation = self.conversations.iter().find(|c| c.thread_id == thread_id);
+                    let conversation = self.sms.conversations.iter().find(|c| c.thread_id == thread_id);
 
                     let addresses = conversation.map(|c| c.addresses.clone());
 
@@ -1316,33 +1199,33 @@ impl Application for ConnectApplet {
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.as_millis() as i64)
                         .unwrap_or(0);
-                    self.last_seen_sms.insert(thread_id, now_ms);
+                    self.sms.last_seen_sms.insert(thread_id, now_ms);
 
-                    self.current_thread_id = Some(thread_id);
-                    self.current_thread_addresses = addresses;
+                    self.sms.current_thread_id = Some(thread_id);
+                    self.sms.current_thread_addresses = addresses;
                     self.view_mode = ViewMode::MessageThread;
 
                     // Reset pagination state
-                    self.messages_loaded_count = 0;
-                    self.messages_has_more = true;
-                    self.scroll_offset_before_load = None;
-                    self.content_height_before_load = None;
+                    self.sms.messages_loaded_count = 0;
+                    self.sms.messages_has_more = true;
+                    self.sms.scroll_offset_before_load = None;
+                    self.sms.content_height_before_load = None;
 
                     // Clear known message IDs for fresh deduplication
-                    self.known_message_ids.clear();
-                    self.messages.clear();
+                    self.sms.known_message_ids.clear();
+                    self.sms.messages.clear();
 
                     // Set up subscription-based loading state
                     // The subscription will fire the D-Bus request after setting up match rules
-                    self.conversation_load_active = true;
-                    self.initial_load_complete = false;
-                    self.loading_thread_id = Some(thread_id);
+                    self.sms.conversation_load_active = true;
+                    self.sms.initial_load_complete = false;
+                    self.sms.loading_thread_id = Some(thread_id);
 
                     // Always load through daemon to ensure its cache is primed
                     // (replyToConversation requires the daemon to have loaded the conversation)
-                    self.sms_loading_state =
+                    self.sms.sms_loading_state =
                         SmsLoadingState::LoadingMessages(LoadingPhase::Connecting);
-                    self.message_sync_active = false;
+                    self.sms.message_sync_active = false;
                     tracing::info!(
                         "Opening conversation thread: {} (subscription-based loading)",
                         thread_id
@@ -1352,29 +1235,29 @@ impl Application for ConnectApplet {
             }
             Message::CloseConversation => {
                 self.view_mode = ViewMode::ConversationList;
-                self.current_thread_id = None;
-                self.current_thread_addresses = None;
-                self.current_thread_sub_id = None;
-                self.messages.clear();
-                self.sms_compose_text.clear();
-                self.sms_sending = false;
-                self.sms_sending_body = None;
-                self.message_sync_active = false;
+                self.sms.current_thread_id = None;
+                self.sms.current_thread_addresses = None;
+                self.sms.current_thread_sub_id = None;
+                self.sms.messages.clear();
+                self.sms.sms_compose_text.clear();
+                self.sms.sms_sending = false;
+                self.sms.sms_sending_body = None;
+                self.sms.message_sync_active = false;
 
                 // Clear subscription-based loading state
-                self.conversation_load_active = false;
-                self.initial_load_complete = false;
-                self.loading_thread_id = None;
-                self.known_message_ids.clear();
+                self.sms.conversation_load_active = false;
+                self.sms.initial_load_complete = false;
+                self.sms.loading_thread_id = None;
+                self.sms.known_message_ids.clear();
 
                 // Increment key to reset scroll position
-                self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
+                self.sms.conversation_list_key = self.sms.conversation_list_key.wrapping_add(1);
 
                 // Refresh conversations in background
-                if let (Some(conn), Some(device_id)) = (&self.dbus_connection, &self.sms_device_id)
+                if let (Some(conn), Some(device_id)) = (&self.dbus_connection, &self.sms.sms_device_id)
                 {
-                    if self.conversations.is_empty() {
-                        self.sms_loading_state =
+                    if self.sms.conversations.is_empty() {
+                        self.sms.sms_loading_state =
                             SmsLoadingState::LoadingConversations(LoadingPhase::Connecting);
                     }
                     return cosmic::app::Task::perform(
@@ -1382,14 +1265,14 @@ impl Application for ConnectApplet {
                         cosmic::Action::App,
                     );
                 }
-                self.sms_loading_state = SmsLoadingState::Idle;
+                self.sms.sms_loading_state = SmsLoadingState::Idle;
             }
             Message::ConversationsLoaded(convs) => {
                 // Slow path: full sync complete from phone (legacy batch loading)
                 tracing::info!(
                     "Background sync complete: {} conversations (had {} cached)",
                     convs.len(),
-                    self.conversations.len()
+                    self.sms.conversations.len()
                 );
                 // Only update if we got conversations back
                 if !convs.is_empty() {
@@ -1397,29 +1280,29 @@ impl Application for ConnectApplet {
                     // for messages that already exist in loaded conversations
                     for conv in &convs {
                         // Only update if we don't have a newer timestamp already
-                        let current = self.last_seen_sms.get(&conv.thread_id).copied();
+                        let current = self.sms.last_seen_sms.get(&conv.thread_id).copied();
                         if current.is_none() || current < Some(conv.timestamp) {
-                            self.last_seen_sms.insert(conv.thread_id, conv.timestamp);
+                            self.sms.last_seen_sms.insert(conv.thread_id, conv.timestamp);
                         }
                     }
 
-                    self.conversations = convs;
-                    self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
+                    self.sms.conversations = convs;
+                    self.sms.conversation_list_key = self.sms.conversation_list_key.wrapping_add(1);
                 }
                 // Background sync complete - clear sync indicator
-                self.conversation_sync_active = false;
+                self.sms.conversation_sync_active = false;
                 // Reset loading state if still loading
                 if matches!(
-                    self.sms_loading_state,
+                    self.sms.sms_loading_state,
                     SmsLoadingState::LoadingConversations(_)
                 ) {
-                    self.sms_loading_state = SmsLoadingState::Idle;
+                    self.sms.sms_loading_state = SmsLoadingState::Idle;
                 }
             }
 
             Message::SmsPrefetchReady(device_id, conversations) => {
                 if !conversations.is_empty() {
-                    self.sms_prefetch = Some((device_id, conversations));
+                    self.sms.sms_prefetch = Some((device_id, conversations));
                 }
             }
 
@@ -1429,17 +1312,18 @@ impl Application for ConnectApplet {
                 conversation,
             } => {
                 // Guard: Only process if for current device
-                if self.sms_device_id.as_ref() != Some(&device_id) {
+                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
                     tracing::debug!(
                         "Ignoring conversation for device {} (current: {:?})",
                         device_id,
-                        self.sms_device_id
+                        self.sms.sms_device_id
                     );
                     return cosmic::app::Task::none();
                 }
 
                 // Update or insert conversation by thread_id
                 if let Some(existing) = self
+                    .sms
                     .conversations
                     .iter_mut()
                     .find(|c| c.thread_id == conversation.thread_id)
@@ -1454,62 +1338,62 @@ impl Application for ConnectApplet {
                     }
                 } else {
                     // Insert new conversation
-                    self.conversations.push(conversation.clone());
+                    self.sms.conversations.push(conversation.clone());
                     tracing::debug!("Added new conversation thread {}", conversation.thread_id);
                 }
 
                 // Re-sort by timestamp (newest first) and truncate
-                self.conversations
+                self.sms.conversations
                     .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
-                self.conversations
+                self.sms.conversations
                     .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
 
                 // Update last_seen for notification deduplication
-                let current = self.last_seen_sms.get(&conversation.thread_id).copied();
+                let current = self.sms.last_seen_sms.get(&conversation.thread_id).copied();
                 if current.is_none() || current < Some(conversation.timestamp) {
-                    self.last_seen_sms
+                    self.sms.last_seen_sms
                         .insert(conversation.thread_id, conversation.timestamp);
                 }
 
                 // Transition from loading spinner to showing data (but keep sync indicator)
                 if matches!(
-                    self.sms_loading_state,
+                    self.sms.sms_loading_state,
                     SmsLoadingState::LoadingConversations(_)
                 ) {
-                    self.sms_loading_state = SmsLoadingState::Idle;
+                    self.sms.sms_loading_state = SmsLoadingState::Idle;
                 }
             }
             Message::ConversationSyncStarted { device_id } => {
                 // Guard: Only process if for current device
-                if self.sms_device_id.as_ref() != Some(&device_id) {
+                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
                     return cosmic::app::Task::none();
                 }
 
                 tracing::debug!("Conversation sync started for device {}", device_id);
                 // Update loading phase to indicate we're waiting for signals
                 if matches!(
-                    self.sms_loading_state,
+                    self.sms.sms_loading_state,
                     SmsLoadingState::LoadingConversations(LoadingPhase::Connecting)
                 ) {
-                    self.sms_loading_state =
+                    self.sms.sms_loading_state =
                         SmsLoadingState::LoadingConversations(LoadingPhase::Requesting);
                 }
             }
             Message::ConversationSyncComplete { device_id } => {
                 // Guard: Only process if for current device
-                if self.sms_device_id.as_ref() != Some(&device_id) {
+                if self.sms.sms_device_id.as_ref() != Some(&device_id) {
                     return cosmic::app::Task::none();
                 }
 
                 tracing::info!(
                     "Conversation sync indicator dismissed for device {}, {} conversations loaded",
                     device_id,
-                    self.conversations.len()
+                    self.sms.conversations.len()
                 );
 
                 // Clear sync indicator only. The subscription keeps running
                 // to catch new conversations while the SMS view is open.
-                self.conversation_sync_active = false;
+                self.sms.conversation_sync_active = false;
 
                 // Only dismiss loading spinner if we have data to show.
                 // If conversations is empty, keep the spinner — the subscription
@@ -1517,35 +1401,35 @@ impl Application for ConnectApplet {
                 // This prevents a false "no conversations" message on cold start
                 // when the phone is slow to respond.
                 if matches!(
-                    self.sms_loading_state,
+                    self.sms.sms_loading_state,
                     SmsLoadingState::LoadingConversations(_)
-                ) && !self.conversations.is_empty()
+                ) && !self.sms.conversations.is_empty()
                 {
-                    self.sms_loading_state = SmsLoadingState::Idle;
+                    self.sms.sms_loading_state = SmsLoadingState::Idle;
                 }
             }
 
             Message::ContactsLoaded(device_id, contacts) => {
                 // Only update if contacts are for the current SMS device
-                if self.sms_device_id.as_ref() == Some(&device_id) {
+                if self.sms.sms_device_id.as_ref() == Some(&device_id) {
                     tracing::info!(
                         "Loaded {} contacts for device {}",
                         contacts.len(),
                         device_id
                     );
-                    self.contacts = contacts;
+                    self.sms.contacts = contacts;
                 } else {
                     tracing::debug!(
                         "Ignoring contacts for device {} (current: {:?})",
                         device_id,
-                        self.sms_device_id
+                        self.sms.sms_device_id
                     );
                 }
             }
             Message::LoadMoreConversations => {
                 // Show 10 more conversations (up to total available)
-                self.conversations_displayed =
-                    (self.conversations_displayed + 10).min(self.conversations.len());
+                self.sms.conversations_displayed =
+                    (self.sms.conversations_displayed + 10).min(self.sms.conversations.len());
             }
             Message::OlderMessagesLoaded(
                 thread_id,
@@ -1554,18 +1438,18 @@ impl Application for ConnectApplet {
                 total_count,
             ) => {
                 // Only reset to Idle if we're currently loading more messages
-                if matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages) {
-                    self.sms_loading_state = SmsLoadingState::Idle;
+                if matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMoreMessages) {
+                    self.sms.sms_loading_state = SmsLoadingState::Idle;
                 }
 
-                if self.current_thread_id == Some(thread_id) {
+                if self.sms.current_thread_id == Some(thread_id) {
                     // Filter out messages already known (safety net for signal cross-talk)
                     let older_msgs: Vec<_> = older_msgs
                         .into_iter()
-                        .filter(|m| !self.known_message_ids.contains(&m.uid))
+                        .filter(|m| !self.sms.known_message_ids.contains(&m.uid))
                         .collect();
                     for m in &older_msgs {
-                        self.known_message_ids.insert(m.uid);
+                        self.sms.known_message_ids.insert(m.uid);
                     }
 
                     if !older_msgs.is_empty() {
@@ -1574,22 +1458,22 @@ impl Application for ConnectApplet {
                             "Prepending {} older messages to thread {} (had {}, total: {:?})",
                             prepended_count,
                             thread_id,
-                            self.messages.len(),
+                            self.sms.messages.len(),
                             total_count
                         );
 
                         // Prepend older messages (they come sorted oldest first)
                         let mut combined = older_msgs;
-                        combined.append(&mut self.messages);
-                        self.messages = combined;
+                        combined.append(&mut self.sms.messages);
+                        self.sms.messages = combined;
 
                         // Update loaded count
-                        self.messages_loaded_count = self.messages.len() as u32;
+                        self.sms.messages_loaded_count = self.sms.messages.len() as u32;
 
                         // Use total_count for accurate pagination if available,
                         // otherwise fall back to heuristic
-                        self.messages_has_more = match total_count {
-                            Some(total) => (self.messages.len() as u64) < total,
+                        self.sms.messages_has_more = match total_count {
+                            Some(total) => (self.sms.messages.len() as u64) < total,
                             None => has_more_heuristic,
                         };
 
@@ -1597,8 +1481,8 @@ impl Application for ConnectApplet {
                         // When we prepend messages, the content shifts down. We need to
                         // scroll down by the estimated height of the prepended content.
                         if let (Some(old_offset), Some(old_height)) = (
-                            self.scroll_offset_before_load.take(),
-                            self.content_height_before_load.take(),
+                            self.sms.scroll_offset_before_load.take(),
+                            self.sms.content_height_before_load.take(),
                         ) {
                             // Estimate prepended content height (avg ~70px per message)
                             const ESTIMATED_MSG_HEIGHT: f32 = 70.0;
@@ -1625,10 +1509,10 @@ impl Application for ConnectApplet {
                     } else {
                         tracing::info!("No older messages returned for thread {}", thread_id);
                         // No more messages available
-                        self.messages_has_more = false;
+                        self.sms.messages_has_more = false;
                         // Clear scroll state
-                        self.scroll_offset_before_load = None;
-                        self.content_height_before_load = None;
+                        self.sms.scroll_offset_before_load = None;
+                        self.sms.content_height_before_load = None;
                     }
                 }
             }
@@ -1641,10 +1525,10 @@ impl Application for ConnectApplet {
                 let content_height = viewport.content_bounds().height;
 
                 if scroll_offset < PREFETCH_THRESHOLD_PX
-                    && self.messages_has_more
+                    && self.sms.messages_has_more
                     && !self.is_loading_more_messages()
-                    && self.initial_load_complete
-                    && !self.messages.is_empty()
+                    && self.sms.initial_load_complete
+                    && !self.sms.messages.is_empty()
                 {
                     tracing::debug!(
                         "Prefetching older messages (scroll_y={:.1}px, content_height={:.1}px)",
@@ -1653,17 +1537,17 @@ impl Application for ConnectApplet {
                     );
 
                     // Store scroll state for position preservation after load
-                    self.scroll_offset_before_load = Some(scroll_offset);
-                    self.content_height_before_load = Some(content_height);
+                    self.sms.scroll_offset_before_load = Some(scroll_offset);
+                    self.sms.content_height_before_load = Some(content_height);
 
                     // Trigger loading older messages (same logic as LoadMoreMessages)
                     if let (Some(conn), Some(device_id), Some(thread_id)) = (
                         &self.dbus_connection,
-                        &self.sms_device_id,
-                        self.current_thread_id,
+                        &self.sms.sms_device_id,
+                        self.sms.current_thread_id,
                     ) {
-                        self.sms_loading_state = SmsLoadingState::LoadingMoreMessages;
-                        let start_index = self.messages_loaded_count;
+                        self.sms.sms_loading_state = SmsLoadingState::LoadingMoreMessages;
+                        let start_index = self.sms.messages_loaded_count;
                         let count = self.config.messages_per_page;
 
                         return cosmic::app::Task::perform(
@@ -1681,9 +1565,9 @@ impl Application for ConnectApplet {
             }
 
             Message::BubblePressStarted { uid, body } => {
-                self.pressed_bubble_uid = Some(uid);
-                self.pressed_bubble_body = Some(body);
-                self.show_copy_hint = false;
+                self.sms.pressed_bubble_uid = Some(uid);
+                self.sms.pressed_bubble_body = Some(body);
+                self.sms.show_copy_hint = false;
                 // Spawn delayed task - fires after 500ms to show hint
                 return cosmic::app::Task::perform(
                     async {
@@ -1695,15 +1579,15 @@ impl Application for ConnectApplet {
 
             Message::BubblePressReleased => {
                 // Clear pressed state - cancels the long-press action
-                self.pressed_bubble_uid = None;
-                self.pressed_bubble_body = None;
-                self.show_copy_hint = false;
+                self.sms.pressed_bubble_uid = None;
+                self.sms.pressed_bubble_body = None;
+                self.sms.show_copy_hint = false;
             }
 
             Message::BubbleHintTimer => {
                 // 500ms elapsed - show "Hold to copy" hint and start 1.5s timer for actual copy
-                if self.pressed_bubble_uid.is_some() {
-                    self.show_copy_hint = true;
+                if self.sms.pressed_bubble_uid.is_some() {
+                    self.sms.show_copy_hint = true;
                     return cosmic::app::Task::perform(
                         async {
                             tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
@@ -1715,9 +1599,9 @@ impl Application for ConnectApplet {
 
             Message::BubbleLongPressComplete => {
                 // 2s total elapsed - copy to clipboard if still pressed
-                if let Some(body) = self.pressed_bubble_body.take() {
-                    self.pressed_bubble_uid = None;
-                    self.show_copy_hint = false;
+                if let Some(body) = self.sms.pressed_bubble_body.take() {
+                    self.sms.pressed_bubble_uid = None;
+                    self.sms.show_copy_hint = false;
                     return clipboard::write(body);
                 }
             }
@@ -1725,28 +1609,28 @@ impl Application for ConnectApplet {
             // Subscription-based message loading handlers
             Message::ConversationLoadStarted { thread_id } => {
                 // D-Bus request fired, subscription is now active
-                if self.current_thread_id == Some(thread_id) {
+                if self.sms.current_thread_id == Some(thread_id) {
                     tracing::debug!(
                         "Conversation {} load started, waiting for subscription signals",
                         thread_id
                     );
                     // Update loading phase to indicate we're waiting for signals
                     if matches!(
-                        self.sms_loading_state,
+                        self.sms.sms_loading_state,
                         SmsLoadingState::LoadingMessages(LoadingPhase::Connecting)
                     ) {
-                        self.sms_loading_state =
+                        self.sms.sms_loading_state =
                             SmsLoadingState::LoadingMessages(LoadingPhase::Requesting);
                     }
                 }
             }
             Message::ConversationMessageReceived { thread_id, message } => {
                 // Guard: Only process if still viewing this thread
-                if self.current_thread_id != Some(thread_id) {
+                if self.sms.current_thread_id != Some(thread_id) {
                     tracing::debug!(
                         "Ignoring message for thread {} (current: {:?})",
                         thread_id,
-                        self.current_thread_id
+                        self.sms.current_thread_id
                     );
                     return cosmic::app::Task::none();
                 }
@@ -1757,7 +1641,7 @@ impl Application for ConnectApplet {
                 if message.uid != OPTIMISTIC_MESSAGE_UID
                     && message.message_type == MessageType::Sent
                 {
-                    if let Some(pos) = self.messages.iter().position(|m| {
+                    if let Some(pos) = self.sms.messages.iter().position(|m| {
                         m.uid == OPTIMISTIC_MESSAGE_UID
                             && m.message_type == MessageType::Sent
                             && m.body == message.body
@@ -1767,17 +1651,17 @@ impl Application for ConnectApplet {
                             "Reconciling optimistic message with real uid={}",
                             message.uid
                         );
-                        self.messages[pos].uid = message.uid;
-                        self.messages[pos].date = message.date;
-                        self.known_message_ids.remove(&OPTIMISTIC_MESSAGE_UID);
-                        self.known_message_ids.insert(message.uid);
-                        self.sms_sending_body = None;
+                        self.sms.messages[pos].uid = message.uid;
+                        self.sms.messages[pos].date = message.date;
+                        self.sms.known_message_ids.remove(&OPTIMISTIC_MESSAGE_UID);
+                        self.sms.known_message_ids.insert(message.uid);
+                        self.sms.sms_sending_body = None;
                         return cosmic::app::Task::none();
                     }
                 }
 
                 // Deduplication: skip if already have this message
-                if self.known_message_ids.contains(&message.uid) {
+                if self.sms.known_message_ids.contains(&message.uid) {
                     tracing::debug!(
                         "Skipping duplicate message uid={} for thread {}",
                         message.uid,
@@ -1785,41 +1669,42 @@ impl Application for ConnectApplet {
                     );
                     return cosmic::app::Task::none();
                 }
-                self.known_message_ids.insert(message.uid);
+                self.sms.known_message_ids.insert(message.uid);
 
                 // Extract sub_id from first message (for MMS group messaging)
-                if self.current_thread_sub_id.is_none() {
-                    self.current_thread_sub_id = Some(message.sub_id);
+                if self.sms.current_thread_sub_id.is_none() {
+                    self.sms.current_thread_sub_id = Some(message.sub_id);
                     tracing::debug!("Set sub_id to {} for thread {}", message.sub_id, thread_id);
                 }
 
                 // Check if this confirms our pending sent message
-                let confirmed_send = self.sms_sending_body.is_some()
+                let confirmed_send = self.sms.sms_sending_body.is_some()
                     && message.message_type == MessageType::Sent
-                    && self.sms_sending_body.as_deref() == Some(message.body.as_str());
+                    && self.sms.sms_sending_body.as_deref() == Some(message.body.as_str());
                 if confirmed_send {
                     tracing::info!("Confirmed delivery of sent message uid={}", message.uid);
-                    self.sms_sending_body = None;
+                    self.sms.sms_sending_body = None;
                 }
 
                 // Insert message in sorted order by date
                 let insert_pos = self
+                    .sms
                     .messages
                     .iter()
                     .position(|m| m.date > message.date)
-                    .unwrap_or(self.messages.len());
-                self.messages.insert(insert_pos, message);
+                    .unwrap_or(self.sms.messages.len());
+                self.sms.messages.insert(insert_pos, message);
 
                 tracing::debug!(
                     "Added message to thread {}, now have {} messages",
                     thread_id,
-                    self.messages.len()
+                    self.sms.messages.len()
                 );
 
                 // Clear loading spinner after first message, show sync indicator instead
-                if matches!(self.sms_loading_state, SmsLoadingState::LoadingMessages(_)) {
-                    self.sms_loading_state = SmsLoadingState::Idle;
-                    self.message_sync_active = true;
+                if matches!(self.sms.sms_loading_state, SmsLoadingState::LoadingMessages(_)) {
+                    self.sms.sms_loading_state = SmsLoadingState::Idle;
+                    self.sms.message_sync_active = true;
                 }
 
                 // Scroll to bottom when a sent message is confirmed.
@@ -1840,7 +1725,7 @@ impl Application for ConnectApplet {
                 // pinned at the top of an oldest-first list. Bounded by
                 // `initial_load_complete` so we don't yank a user reading
                 // older messages when a new SMS arrives later.
-                if !self.initial_load_complete {
+                if !self.sms.initial_load_complete {
                     return scrollable::snap_to(
                         widget::Id::new("message-thread"),
                         scrollable::RelativeOffset::END.into(),
@@ -1854,14 +1739,14 @@ impl Application for ConnectApplet {
             } => {
                 // Local store read complete - scroll to show messages while
                 // continuing to listen for phone response data
-                if self.current_thread_id != Some(thread_id) {
+                if self.sms.current_thread_id != Some(thread_id) {
                     return cosmic::app::Task::none();
                 }
 
                 tracing::info!(
                     "Local store loaded for thread {}: {} messages displayed, {} total in store",
                     thread_id,
-                    self.messages.len(),
+                    self.sms.messages.len(),
                     total_count
                 );
 
@@ -1869,16 +1754,16 @@ impl Application for ConnectApplet {
                 // Note: total_count from conversationLoaded reflects the LOCAL store count,
                 // which may be 0 or 1 after a reboot. Use a heuristic instead: if we've
                 // loaded a full page, there are likely more messages available.
-                self.messages_loaded_count = self.messages.len() as u32;
-                self.messages_has_more =
-                    if total_count > 0 && (self.messages.len() as u64) < total_count {
+                self.sms.messages_loaded_count = self.sms.messages.len() as u32;
+                self.sms.messages_has_more =
+                    if total_count > 0 && (self.sms.messages.len() as u64) < total_count {
                         true
                     } else {
-                        self.messages.len() >= self.config.messages_per_page as usize
+                        self.sms.messages.len() >= self.config.messages_per_page as usize
                     };
 
                 // Scroll to bottom to show latest messages
-                if !self.messages.is_empty() {
+                if !self.sms.messages.is_empty() {
                     return scrollable::snap_to(
                         widget::Id::new("message-thread"),
                         scrollable::RelativeOffset::END.into(),
@@ -1890,11 +1775,11 @@ impl Application for ConnectApplet {
                 total_count,
             } => {
                 // Guard: Only process if still viewing this thread
-                if self.current_thread_id != Some(thread_id) {
+                if self.sms.current_thread_id != Some(thread_id) {
                     tracing::debug!(
                         "Ignoring load complete for thread {} (current: {:?})",
                         thread_id,
-                        self.current_thread_id
+                        self.sms.current_thread_id
                     );
                     return cosmic::app::Task::none();
                 }
@@ -1902,41 +1787,41 @@ impl Application for ConnectApplet {
                 tracing::info!(
                     "Conversation {} loading complete: {} messages loaded, {} total in conversation",
                     thread_id,
-                    self.messages.len(),
+                    self.sms.messages.len(),
                     total_count
                 );
 
                 // Messages are already sorted during insertion, but sort again as safety
-                self.messages.sort_by_key(|m| m.date);
+                self.sms.messages.sort_by_key(|m| m.date);
 
                 // Update pagination state
                 // Note: total_count from conversationLoaded reflects the LOCAL store count,
                 // not the phone's total. Use a heuristic: if we've loaded a full page
                 // worth of messages, there are likely more available.
-                self.messages_loaded_count = self.messages.len() as u32;
-                self.messages_has_more =
-                    if total_count > 0 && (self.messages.len() as u64) < total_count {
+                self.sms.messages_loaded_count = self.sms.messages.len() as u32;
+                self.sms.messages_has_more =
+                    if total_count > 0 && (self.sms.messages.len() as u64) < total_count {
                         true
                     } else {
-                        self.messages.len() >= self.config.messages_per_page as usize
+                        self.sms.messages.len() >= self.config.messages_per_page as usize
                     };
 
                 // Update last_seen_sms with the newest message timestamp
-                if let Some(newest) = self.messages.iter().map(|m| m.date).max() {
-                    let current = self.last_seen_sms.get(&thread_id).copied();
+                if let Some(newest) = self.sms.messages.iter().map(|m| m.date).max() {
+                    let current = self.sms.last_seen_sms.get(&thread_id).copied();
                     if current.is_none() || current < Some(newest) {
-                        self.last_seen_sms.insert(thread_id, newest);
+                        self.sms.last_seen_sms.insert(thread_id, newest);
                     }
                 }
 
                 // Clear sync indicator and loading state. The subscription keeps
                 // running to catch new messages (including sent message echoes).
-                self.message_sync_active = false;
-                self.initial_load_complete = true;
-                self.sms_loading_state = SmsLoadingState::Idle;
+                self.sms.message_sync_active = false;
+                self.sms.initial_load_complete = true;
+                self.sms.sms_loading_state = SmsLoadingState::Idle;
 
                 // Scroll to bottom if we loaded messages
-                if !self.messages.is_empty() {
+                if !self.sms.messages.is_empty() {
                     return scrollable::snap_to(
                         widget::Id::new("message-thread"),
                         scrollable::RelativeOffset::END.into(),
@@ -1946,35 +1831,35 @@ impl Application for ConnectApplet {
 
             Message::SmsError(err) => {
                 tracing::error!("SMS error: {}", err);
-                self.sms_loading_state = SmsLoadingState::Idle;
+                self.sms.sms_loading_state = SmsLoadingState::Idle;
                 // Also clear subscription state on error
-                self.conversation_load_active = false;
-                self.conversation_list_subscription_active = false;
-                self.message_sync_active = false;
+                self.sms.conversation_load_active = false;
+                self.sms.conversation_list_subscription_active = false;
+                self.sms.message_sync_active = false;
                 return self.set_transient_status(format!("SMS error: {}", err));
             }
             Message::SmsComposeInput(text) => {
-                self.sms_compose_text = text;
+                self.sms.sms_compose_text = text;
             }
             Message::SendSms => {
                 tracing::info!("SendSms triggered");
                 tracing::info!(
                     "State: conn={}, device_id={:?}, thread_id={:?}, text_empty={}, sending={}",
                     self.dbus_connection.is_some(),
-                    self.sms_device_id,
-                    self.current_thread_id,
-                    self.sms_compose_text.is_empty(),
-                    self.sms_sending
+                    self.sms.sms_device_id,
+                    self.sms.current_thread_id,
+                    self.sms.sms_compose_text.is_empty(),
+                    self.sms.sms_sending
                 );
                 if let (Some(conn), Some(device_id), Some(thread_id)) = (
                     &self.dbus_connection,
-                    &self.sms_device_id,
-                    self.current_thread_id,
+                    &self.sms.sms_device_id,
+                    self.sms.current_thread_id,
                 ) {
-                    if !self.sms_compose_text.is_empty() && !self.sms_sending {
-                        let message_text = self.sms_compose_text.clone();
-                        self.sms_sending = true;
-                        self.sms_sending_body = Some(message_text.clone());
+                    if !self.sms.sms_compose_text.is_empty() && !self.sms.sms_sending {
+                        let message_text = self.sms.sms_compose_text.clone();
+                        self.sms.sms_sending = true;
+                        self.sms.sms_sending_body = Some(message_text.clone());
                         tracing::info!(
                             "Dispatching send_sms_async via replyToConversation for thread_id={}",
                             thread_id
@@ -1991,8 +1876,8 @@ impl Application for ConnectApplet {
                     } else {
                         tracing::warn!(
                             "SendSms conditions not met: text_empty={}, sending={}",
-                            self.sms_compose_text.is_empty(),
-                            self.sms_sending
+                            self.sms.sms_compose_text.is_empty(),
+                            self.sms.sms_sending
                         );
                     }
                 } else {
@@ -2000,13 +1885,13 @@ impl Application for ConnectApplet {
                 }
             }
             Message::SmsSendResult(result) => {
-                self.sms_sending = false;
+                self.sms.sms_sending = false;
                 match result {
                     Ok(sent_body) => {
                         tracing::info!("SMS sent successfully");
-                        self.sms_compose_text.clear();
+                        self.sms.sms_compose_text.clear();
 
-                        if let Some(thread_id) = self.current_thread_id {
+                        if let Some(thread_id) = self.sms.current_thread_id {
                             let now_ms = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .map(|d| d.as_millis() as i64)
@@ -2018,6 +1903,7 @@ impl Application for ConnectApplet {
                             // Update conversation list preview so it reflects the new message
                             // when user navigates back
                             if let Some(conv) = self
+                                .sms
                                 .conversations
                                 .iter_mut()
                                 .find(|c| c.thread_id == thread_id)
@@ -2025,17 +1911,18 @@ impl Application for ConnectApplet {
                                 conv.last_message = sent_body;
                                 conv.timestamp = now_ms;
                             }
-                            self.conversations
+                            self.sms.conversations
                                 .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
 
                             // Insert optimistic message if echo hasn't already arrived.
                             // sms_sending_body is cleared by confirmed_send in
                             // ConversationMessageReceived if the echo arrived before
                             // SmsSendResult — skip to avoid duplicate.
-                            if self.sms_sending_body.is_some() {
+                            if self.sms.sms_sending_body.is_some() {
                                 let optimistic = SmsMessage {
                                     body: optimistic_body,
                                     addresses: self
+                                        .sms
                                         .current_thread_addresses
                                         .clone()
                                         .unwrap_or_default(),
@@ -2044,12 +1931,12 @@ impl Application for ConnectApplet {
                                     read: true,
                                     thread_id,
                                     uid: OPTIMISTIC_MESSAGE_UID,
-                                    sub_id: self.current_thread_sub_id.unwrap_or(-1),
+                                    sub_id: self.sms.current_thread_sub_id.unwrap_or(-1),
                                     attachments: vec![],
                                 };
-                                self.messages.push(optimistic);
-                                self.known_message_ids.insert(OPTIMISTIC_MESSAGE_UID);
-                                self.sms_sending_body = None;
+                                self.sms.messages.push(optimistic);
+                                self.sms.known_message_ids.insert(OPTIMISTIC_MESSAGE_UID);
+                                self.sms.sms_sending_body = None;
 
                                 // No subscription restart needed — the message subscription
                                 // runs as long as the thread is open and will catch the
@@ -2066,7 +1953,7 @@ impl Application for ConnectApplet {
                     }
                     Err(err) => {
                         tracing::error!("SMS send error: {}", err);
-                        self.sms_sending_body = None;
+                        self.sms.sms_sending_body = None;
                         return self.set_transient_status(format!(
                             "{}: {}",
                             fl!("sms-failed"),
@@ -2078,65 +1965,66 @@ impl Application for ConnectApplet {
             // New message
             Message::OpenNewMessage => {
                 self.view_mode = ViewMode::NewMessage;
-                self.new_message_recipients.clear();
-                self.new_message_recipient_input.clear();
-                self.new_message_body.clear();
-                self.new_message_sending = false;
-                self.contact_suggestions.clear();
+                self.sms.new_message_recipients.clear();
+                self.sms.new_message_recipient_input.clear();
+                self.sms.new_message_body.clear();
+                self.sms.new_message_sending = false;
+                self.sms.contact_suggestions.clear();
                 return widget::text_input::focus(widget::Id::new("new-message-recipient"));
             }
             Message::CloseNewMessage => {
                 self.view_mode = ViewMode::ConversationList;
-                self.new_message_recipients.clear();
-                self.new_message_recipient_input.clear();
-                self.new_message_body.clear();
-                self.new_message_sending = false;
+                self.sms.new_message_recipients.clear();
+                self.sms.new_message_recipient_input.clear();
+                self.sms.new_message_body.clear();
+                self.sms.new_message_sending = false;
             }
             Message::NewMessageRecipientInput(text) => {
-                self.contact_suggestions = self.generate_contact_suggestions_filtered(&text, 10);
-                self.new_message_recipient_input = text;
+                self.sms.contact_suggestions = self.generate_contact_suggestions_filtered(&text, 10);
+                self.sms.new_message_recipient_input = text;
             }
             Message::NewMessageBodyInput(text) => {
-                self.new_message_body = text;
+                self.sms.new_message_body = text;
             }
             Message::AddManualRecipient => {
-                let input = self.new_message_recipient_input.trim().to_string();
+                let input = self.sms.new_message_recipient_input.trim().to_string();
                 if is_address_valid(&input) && !self.is_recipient_duplicate(&input) {
-                    let display = self.contacts.get_name_or_number(&input);
-                    self.new_message_recipients.push((display, input));
-                    self.new_message_recipient_input.clear();
-                    self.contact_suggestions.clear();
+                    let display = self.sms.contacts.get_name_or_number(&input);
+                    self.sms.new_message_recipients.push((display, input));
+                    self.sms.new_message_recipient_input.clear();
+                    self.sms.contact_suggestions.clear();
                     return widget::text_input::focus(widget::Id::new("new-message-recipient"));
                 }
             }
             Message::RemoveRecipient(index) => {
-                if index < self.new_message_recipients.len() {
-                    self.new_message_recipients.remove(index);
+                if index < self.sms.new_message_recipients.len() {
+                    self.sms.new_message_recipients.remove(index);
                 }
             }
             Message::SelectContact(_name, phone) => {
                 if !self.is_recipient_duplicate(&phone) {
-                    let display = self.contacts.get_name_or_number(&phone);
-                    self.new_message_recipients.push((display, phone));
-                    self.new_message_recipient_input.clear();
-                    self.contact_suggestions.clear();
+                    let display = self.sms.contacts.get_name_or_number(&phone);
+                    self.sms.new_message_recipients.push((display, phone));
+                    self.sms.new_message_recipient_input.clear();
+                    self.sms.contact_suggestions.clear();
                     return widget::text_input::focus(widget::Id::new("new-message-recipient"));
                 }
             }
             Message::SendNewMessage => {
-                if let (Some(conn), Some(device_id)) = (&self.dbus_connection, &self.sms_device_id)
+                if let (Some(conn), Some(device_id)) = (&self.dbus_connection, &self.sms.sms_device_id)
                 {
-                    if !self.new_message_recipients.is_empty()
-                        && !self.new_message_body.is_empty()
-                        && !self.new_message_sending
+                    if !self.sms.new_message_recipients.is_empty()
+                        && !self.sms.new_message_body.is_empty()
+                        && !self.sms.new_message_sending
                     {
                         let recipients: Vec<String> = self
+                            .sms
                             .new_message_recipients
                             .iter()
                             .map(|(_, phone)| phone.clone())
                             .collect();
-                        let message = self.new_message_body.clone();
-                        self.new_message_sending = true;
+                        let message = self.sms.new_message_body.clone();
+                        self.sms.new_message_sending = true;
                         return cosmic::app::Task::perform(
                             send_new_sms_async(
                                 conn.clone(),
@@ -2150,23 +2038,23 @@ impl Application for ConnectApplet {
                 }
             }
             Message::NewMessageSendResult(result) => {
-                self.new_message_sending = false;
+                self.sms.new_message_sending = false;
                 match &result {
                     Ok(msg) => {
                         tracing::info!("New message send result: {}", msg);
                         self.status_message = Some(msg.clone());
                         // Clear fields and return to conversation list
-                        self.new_message_recipients.clear();
-                        self.new_message_recipient_input.clear();
-                        self.new_message_body.clear();
+                        self.sms.new_message_recipients.clear();
+                        self.sms.new_message_recipient_input.clear();
+                        self.sms.new_message_body.clear();
                         self.view_mode = ViewMode::ConversationList;
                         // Enable subscription to catch the new conversation when the phone
                         // syncs back. The subscription listens over a longer window than a
                         // one-shot fetch, giving the phone time to process the send and
                         // emit a conversationCreated signal.
-                        if self.sms_device_id.is_some() {
-                            self.conversation_list_subscription_active = true;
-                            self.conversation_sync_active = true;
+                        if self.sms.sms_device_id.is_some() {
+                            self.sms.conversation_list_subscription_active = true;
+                            self.sms.conversation_sync_active = true;
                         }
                     }
                     Err(err) => {
@@ -2418,14 +2306,14 @@ impl Application for ConnectApplet {
                 }
 
                 // Check if we've already seen this message (deduplication)
-                let last_seen = self.last_seen_sms.get(&message.thread_id).copied();
+                let last_seen = self.sms.last_seen_sms.get(&message.thread_id).copied();
                 if last_seen.is_some() && last_seen >= Some(message.date) {
                     // Already seen this message or an older one
                     return cosmic::app::Task::none();
                 }
 
                 // Update last seen timestamp for this thread
-                self.last_seen_sms.insert(message.thread_id, message.date);
+                self.sms.last_seen_sms.insert(message.thread_id, message.date);
 
                 // Capture config settings
                 let show_sender = self.config.sms_notification_show_sender;
@@ -2435,10 +2323,10 @@ impl Application for ConnectApplet {
 
                 // Resolve sender name: use cached contacts if available, otherwise load from disk
                 let cached_sender_name = if show_sender {
-                    let has_cached_contacts = self.sms_device_id.as_ref() == Some(&device_id)
-                        && !self.contacts.is_empty();
+                    let has_cached_contacts = self.sms.sms_device_id.as_ref() == Some(&device_id)
+                        && !self.sms.contacts.is_empty();
                     if has_cached_contacts {
-                        Some(self.contacts.get_group_display_name(&message.addresses, 3))
+                        Some(self.sms.contacts.get_group_display_name(&message.addresses, 3))
                     } else {
                         None
                     }
@@ -2645,26 +2533,26 @@ impl Application for ConnectApplet {
             ViewMode::Settings => view_settings(&self.config),
             ViewMode::NotificationSettings => view_notification_settings(&self.config),
             ViewMode::ConversationList => view_conversation_list(ConversationListParams {
-                device_name: self.sms_device_name.as_deref(),
-                conversations: &self.conversations,
-                conversations_displayed: self.conversations_displayed,
-                contacts: &self.contacts,
-                loading_state: &self.sms_loading_state,
-                sync_active: self.conversation_sync_active,
+                device_name: self.sms.sms_device_name.as_deref(),
+                conversations: &self.sms.conversations,
+                conversations_displayed: self.sms.conversations_displayed,
+                contacts: &self.sms.contacts,
+                loading_state: &self.sms.sms_loading_state,
+                sync_active: self.sms.conversation_sync_active,
             }),
             ViewMode::MessageThread => {
                 let thread = view_message_thread(MessageThreadParams {
-                    device_id: self.sms_device_id.as_deref().unwrap_or(""),
-                    device_name: self.sms_device_name.as_deref().unwrap_or(""),
-                    thread_addresses: self.current_thread_addresses.as_deref(),
-                    messages: &self.messages,
-                    contacts: &self.contacts,
-                    loading_state: &self.sms_loading_state,
-                    sms_compose_text: &self.sms_compose_text,
-                    sms_sending: self.sms_sending,
-                    sync_active: self.message_sync_active,
-                    pressed_bubble_uid: self.pressed_bubble_uid,
-                    show_copy_hint: self.show_copy_hint,
+                    device_id: self.sms.sms_device_id.as_deref().unwrap_or(""),
+                    device_name: self.sms.sms_device_name.as_deref().unwrap_or(""),
+                    thread_addresses: self.sms.current_thread_addresses.as_deref(),
+                    messages: &self.sms.messages,
+                    contacts: &self.sms.contacts,
+                    loading_state: &self.sms.sms_loading_state,
+                    sms_compose_text: &self.sms.sms_compose_text,
+                    sms_sending: self.sms.sms_sending,
+                    sync_active: self.sms.message_sync_active,
+                    pressed_bubble_uid: self.sms.pressed_bubble_uid,
+                    show_copy_hint: self.sms.show_copy_hint,
                     status_message: self.status_message.as_deref(),
                 });
                 // popup_container uses Shrink height internally, which sets a
@@ -2680,11 +2568,11 @@ impl Application for ConnectApplet {
                     .into()
             }
             ViewMode::NewMessage => view_new_message(NewMessageParams {
-                recipients: &self.new_message_recipients,
-                recipient_input: &self.new_message_recipient_input,
-                body: &self.new_message_body,
-                sending: self.new_message_sending,
-                contact_suggestions: &self.contact_suggestions,
+                recipients: &self.sms.new_message_recipients,
+                recipient_input: &self.sms.new_message_recipient_input,
+                body: &self.sms.new_message_body,
+                sending: self.sms.new_message_sending,
+                contact_suggestions: &self.sms.contact_suggestions,
             }),
             ViewMode::MediaControls => view_media_controls(MediaControlsParams {
                 device_name: self.media_device_name.as_deref(),
@@ -2795,8 +2683,8 @@ impl Application for ConnectApplet {
 
         // Add conversation list subscription for incremental loading
         // This provides real-time UI updates as conversations arrive from the phone
-        if self.conversation_list_subscription_active {
-            if let Some(device_id) = self.sms_device_id.clone() {
+        if self.sms.conversation_list_subscription_active {
+            if let Some(device_id) = self.sms.sms_device_id.clone() {
                 subscriptions.push(Subscription::run_with(
                     ("conversation_list", device_id.clone()),
                     |(_, device_id)| conversation_list_subscription(device_id.clone()),
@@ -2807,9 +2695,9 @@ impl Application for ConnectApplet {
         // Add conversation message subscription when loading a conversation
         // This provides incremental message loading via D-Bus signals
         // The subscription fires the D-Bus request itself after setting up match rules
-        if self.conversation_load_active {
+        if self.sms.conversation_load_active {
             if let (Some(thread_id), Some(device_id)) =
-                (self.loading_thread_id, self.sms_device_id.clone())
+                (self.sms.loading_thread_id, self.sms.sms_device_id.clone())
             {
                 let messages_per_page = self.config.messages_per_page;
                 subscriptions.push(Subscription::run_with(

--- a/cosmic-ext-connected/src/app.rs
+++ b/cosmic-ext-connected/src/app.rs
@@ -1108,7 +1108,6 @@ impl Application for ConnectApplet {
                 self.sms.messages.clear();
                 self.sms.current_thread_id = None;
                 self.sms.current_thread_addresses = None;
-                self.sms.current_thread_sub_id = None;
                 self.sms.current_merged_thread_ids.clear();
                 self.sms.sms_loading_state = SmsLoadingState::Idle;
                 self.sms.conversation_sync_active = false;
@@ -1175,7 +1174,6 @@ impl Application for ConnectApplet {
                 self.view_mode = ViewMode::ConversationList;
                 self.sms.current_thread_id = None;
                 self.sms.current_thread_addresses = None;
-                self.sms.current_thread_sub_id = None;
                 self.sms.current_merged_thread_ids.clear();
                 self.sms.messages.clear();
                 self.sms.sms_compose_text.clear();

--- a/cosmic-ext-connected/src/config.rs
+++ b/cosmic-ext-connected/src/config.rs
@@ -26,6 +26,11 @@ pub struct Config {
     pub sms_notification_show_content: bool,
     /// Show sender name in SMS notifications (privacy)
     pub sms_notification_show_sender: bool,
+    /// Merge iOS reaction-bucket sibling threads into one logical conversation.
+    /// When off, each underlying thread renders separately and replies are sent
+    /// against the user-displayed thread (which can produce duplicate delivery
+    /// on the recipient side for symmetric merges — see v0.5.0 Topic 2).
+    pub merge_reaction_threads: bool,
     /// Enable desktop notifications for incoming/missed calls
     pub call_notifications: bool,
     /// Show phone number in call notifications (privacy)
@@ -49,6 +54,7 @@ impl Default for Config {
             sms_notifications: true,
             sms_notification_show_content: true,
             sms_notification_show_sender: true,
+            merge_reaction_threads: true,
             call_notifications: true,
             call_notification_show_number: true,
             call_notification_show_name: true,

--- a/cosmic-ext-connected/src/notifications.rs
+++ b/cosmic-ext-connected/src/notifications.rs
@@ -118,6 +118,37 @@ fn should_show_notification(dedup_file: &str, key: &str) -> bool {
     should_notify
 }
 
+/// Show a notification and auto-close it after the configured timeout.
+///
+/// COSMIC's notification daemon does not respect the `expire_timeout` hint from
+/// the freedesktop notification spec, so all notifications display for the daemon's
+/// fixed duration regardless of the value passed. To work around this, notifications
+/// are created with `Timeout::Never` (expire_timeout=0) to prevent the daemon from
+/// auto-closing them, then explicitly closed after the user's configured timeout.
+pub async fn show_and_auto_close(
+    notification: notify_rust::Notification,
+    timeout_ms: u32,
+    label: &str,
+) {
+    let label = label.to_string();
+    let result = tokio::task::spawn_blocking(move || notification.show()).await;
+    match result {
+        Ok(Ok(handle)) => {
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(timeout_ms as u64)).await;
+                // close() uses zbus::block_on internally, so run in blocking context
+                let _ = tokio::task::spawn_blocking(move || handle.close()).await;
+            });
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("Failed to show {} notification: {}", label, e);
+        }
+        Err(e) => {
+            tracing::warn!("Notification task panicked: {}", e);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cosmic-ext-connected/src/sms/conversation_subscription.rs
+++ b/cosmic-ext-connected/src/sms/conversation_subscription.rs
@@ -655,6 +655,7 @@ fn summarize_message(sms_msg: kdeconnect_dbus::plugins::SmsMessage) -> Conversat
         timestamp: sms_msg.date,
         unread: !sms_msg.read,
         has_attachments,
+        sub_id: sms_msg.sub_id,
     }
 }
 

--- a/cosmic-ext-connected/src/sms/fetch.rs
+++ b/cosmic-ext-connected/src/sms/fetch.rs
@@ -152,6 +152,7 @@ async fn fetch_conversations_via_signals(
                                     timestamp: msg.date,
                                     unread: !msg.read,
                                     has_attachments,
+                                    sub_id: msg.sub_id,
                                 });
                             }
                         }
@@ -183,6 +184,7 @@ async fn fetch_conversations_via_signals(
                                     timestamp: msg.date,
                                     unread: !msg.read,
                                     has_attachments,
+                                    sub_id: msg.sub_id,
                                 });
                             }
                         }
@@ -248,6 +250,7 @@ async fn fetch_conversations_via_signals(
                                 timestamp: msg.date,
                                 unread: !msg.read,
                                 has_attachments,
+                                sub_id: msg.sub_id,
                             });
                         }
                     }
@@ -269,6 +272,7 @@ async fn fetch_conversations_via_signals(
                                 timestamp: msg.date,
                                 unread: !msg.read,
                                 has_attachments,
+                                sub_id: msg.sub_id,
                             });
                         }
                     }

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -1,12 +1,20 @@
 //! Logical conversation: wraps one-or-more underlying SMS thread IDs that
 //! represent the same user-perceived conversation.
 //!
-//! At M6 every `LogicalConversation` is a 1:1 wrapper around a single
-//! `ConversationSummary` (no merging). M7 introduces the reaction-bucket
-//! merge heuristic via `merge_into_logical`, which collapses split threads
-//! into a single `LogicalConversation` carrying multiple `merged_thread_ids`.
+//! M7 lights up reaction-bucket merging via [`merge_into_logical`], which
+//! collapses split threads (same canonical address-set + same subID) into
+//! a single `LogicalConversation` carrying multiple `merged_thread_ids`.
+//! See `Reaction Thread Splitting - Investigation and Fix Approach.md`
+//! for the design rationale and Phase 1B-validated heuristic.
 
-#![allow(dead_code)] // M7 lights up 'merged_thread_ids', 'subscription_id', 'unread_count'
+// `merged_thread_ids`, `subscription_id`, `unread_count` are populated by
+// `merge_group` but not yet read; M8 (multi-thread subscription) and M11
+// (mark-as-read fan-out) light them up. `is_reaction_bucket` is the
+// pairwise-equivalent of the bucketing in `merge_into_logical`, kept as a
+// public predicate for tests and the future split-by-case reply rule.
+#![allow(dead_code)]
+
+use std::collections::{BTreeSet, HashMap};
 
 use kdeconnect_dbus::plugins::ConversationSummary;
 
@@ -15,18 +23,20 @@ use kdeconnect_dbus::plugins::ConversationSummary;
 /// arriving with slightly-different address-sets).
 #[derive(Debug, Clone)]
 pub struct LogicalConversation {
-    /// Thread ID used for `replyToConversation`. For a 1:1 wrapper this is
-    /// the underlying thread's ID; once merging is active, the split-by-case
-    /// reply rule picks the most-recently-active sibling within a symmetric
-    /// merge group.
+    /// Thread ID used for `replyToConversation` and view subscriptions. For
+    /// merged groups this is the most-recently-active sibling within the
+    /// canonical merge set, matching AOSP's outgoing-reply canonicalization
+    /// (Phase 1B Pair 4 finding).
     pub primary_thread_id: i64,
     /// All underlying thread IDs composing this logical conversation.
-    /// Always contains `primary_thread_id`. Single-element at M6.
+    /// Always contains `primary_thread_id`. Single-element for non-merged.
     pub merged_thread_ids: Vec<i64>,
     /// SIM subscription ID. Merge never crosses subID boundaries, so all
     /// threads in `merged_thread_ids` share this value.
     pub subscription_id: i64,
-    /// Union of every underlying thread's address-set, deduplicated.
+    /// Union of every underlying thread's address-set, deduplicated by
+    /// canonical (digit-only) form. Original carrier formatting preserved
+    /// for the first occurrence of each canonical address.
     pub addresses: Vec<String>,
     /// Preview of the most recent message body across all merged threads.
     pub last_message_preview: String,
@@ -34,13 +44,12 @@ pub struct LogicalConversation {
     pub last_message_timestamp: i64,
     /// Whether the most recent message is an MMS with attachments.
     pub has_attachments: bool,
-    /// Number of underlying threads currently flagged unread. At M6 this is
-    /// `0` or `1` (1:1 wrapper); M7 sums across merged threads.
+    /// Sum of underlying threads currently flagged unread.
     pub unread_count: usize,
 }
 
 impl LogicalConversation {
-    /// Wrap a single underlying conversation 1:1. M6's only construction path.
+    /// Wrap a single underlying conversation 1:1.
     pub fn from_single(cs: ConversationSummary) -> Self {
         Self {
             primary_thread_id: cs.thread_id,
@@ -52,5 +61,362 @@ impl LogicalConversation {
             has_attachments: cs.has_attachments,
             unread_count: if cs.unread { 1 } else { 0 },
         }
+    }
+}
+
+/// Strip non-digit characters; if the result has more than 10 digits and
+/// starts with `1` (US country code), drop the leading `1`. Mirrors
+/// `analyze.py::normalize_addr`.
+pub(crate) fn normalize_addr(addr: &str) -> String {
+    let digits: String = addr.chars().filter(|c| c.is_ascii_digit()).collect();
+    if digits.len() > 10 && digits.starts_with('1') {
+        digits[1..].to_string()
+    } else {
+        digits
+    }
+}
+
+/// Canonical address set: normalize each address, drop empties, deduplicate.
+/// Returned as a sorted `Vec` so equal sets compare equal and the value is
+/// hashable as a `HashMap` key.
+pub(crate) fn canonical_set(addresses: &[String]) -> Vec<String> {
+    let mut set = BTreeSet::new();
+    for addr in addresses {
+        let norm = normalize_addr(addr);
+        if !norm.is_empty() {
+            set.insert(norm);
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Pairwise merge predicate from the validated heuristic
+/// (`analyze.py::is_reaction_bucket`, primary equality clause only).
+///
+/// Returns `true` iff:
+/// - both `sub_id`s are non-`-1` and equal, AND
+/// - canonical address-sets are equal.
+///
+/// The subset clause is intentionally omitted at M7: every Phase 1 capture
+/// pair was symmetric, and the conversation-summary-level body field is too
+/// sparse to drive the reaction-pattern check that the subset clause needs.
+/// Revisit once richer per-message context is available.
+pub(crate) fn is_reaction_bucket(a: &ConversationSummary, b: &ConversationSummary) -> bool {
+    if a.sub_id == -1 || b.sub_id == -1 {
+        return false;
+    }
+    if a.sub_id != b.sub_id {
+        return false;
+    }
+    canonical_set(&a.addresses) == canonical_set(&b.addresses)
+}
+
+/// Group raw conversations into `LogicalConversation`s, merging threads
+/// that share the same canonical address-set and the same `sub_id`
+/// (the [`is_reaction_bucket`] precondition). Conversations with
+/// `sub_id == -1` or an empty canonical address-set are passed through
+/// as 1:1 wrappers — they cannot satisfy the merge precondition.
+///
+/// Output is sorted by `last_message_timestamp` descending, matching the
+/// convention used by the existing single-thread display order.
+pub(crate) fn merge_into_logical(raw: &[ConversationSummary]) -> Vec<LogicalConversation> {
+    let mut groups: HashMap<(Vec<String>, i64), Vec<&ConversationSummary>> = HashMap::new();
+    let mut standalone: Vec<&ConversationSummary> = Vec::new();
+
+    for cs in raw {
+        let canon = canonical_set(&cs.addresses);
+        if cs.sub_id == -1 || canon.is_empty() {
+            standalone.push(cs);
+        } else {
+            groups.entry((canon, cs.sub_id)).or_default().push(cs);
+        }
+    }
+
+    let mut result: Vec<LogicalConversation> = Vec::with_capacity(groups.len() + standalone.len());
+
+    for (_, threads) in groups {
+        if threads.len() == 1 {
+            result.push(LogicalConversation::from_single(threads[0].clone()));
+        } else {
+            result.push(merge_group(threads));
+        }
+    }
+    for cs in standalone {
+        result.push(LogicalConversation::from_single(cs.clone()));
+    }
+
+    result.sort_by_key(|lc| std::cmp::Reverse(lc.last_message_timestamp));
+    result
+}
+
+/// Build one `LogicalConversation` from a group of 2+ `ConversationSummary`
+/// values known to share the same canonical address-set and `sub_id`.
+fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
+    // Most-recently-active sibling becomes the primary, per the symmetric-
+    // split tiebreak rule (Phase 1B: matches AOSP's outgoing-reply
+    // canonicalization, so the echo lands on the threadId we passed).
+    threads.sort_by_key(|cs| std::cmp::Reverse(cs.timestamp));
+    let primary = threads[0];
+
+    let merged_thread_ids: Vec<i64> = threads.iter().map(|cs| cs.thread_id).collect();
+    let subscription_id = primary.sub_id;
+
+    // Address union deduplicated by canonical form, preserving the first-
+    // seen original (carrier-formatted) string for display.
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut addresses: Vec<String> = Vec::new();
+    for cs in &threads {
+        for addr in &cs.addresses {
+            let norm = normalize_addr(addr);
+            if !norm.is_empty() && seen.insert(norm) {
+                addresses.push(addr.clone());
+            }
+        }
+    }
+
+    let unread_count = threads.iter().filter(|cs| cs.unread).count();
+
+    LogicalConversation {
+        primary_thread_id: primary.thread_id,
+        merged_thread_ids,
+        subscription_id,
+        addresses,
+        last_message_preview: primary.last_message.clone(),
+        last_message_timestamp: primary.timestamp,
+        has_attachments: primary.has_attachments,
+        unread_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cs(
+        thread_id: i64,
+        sub_id: i64,
+        addresses: &[&str],
+        timestamp: i64,
+        last_message: &str,
+        unread: bool,
+        has_attachments: bool,
+    ) -> ConversationSummary {
+        ConversationSummary {
+            thread_id,
+            addresses: addresses.iter().map(|s| (*s).to_string()).collect(),
+            last_message: last_message.to_string(),
+            timestamp,
+            unread,
+            has_attachments,
+            sub_id,
+        }
+    }
+
+    #[test]
+    fn normalize_addr_strips_non_digits() {
+        assert_eq!(normalize_addr("(555) 123-4567"), "5551234567");
+        assert_eq!(normalize_addr("+1 555-123-4567"), "5551234567");
+        assert_eq!(normalize_addr("555.123.4567"), "5551234567");
+    }
+
+    #[test]
+    fn normalize_addr_drops_leading_us_country_code() {
+        assert_eq!(normalize_addr("+15551234567"), "5551234567");
+        assert_eq!(normalize_addr("15551234567"), "5551234567");
+    }
+
+    #[test]
+    fn normalize_addr_keeps_short_strings_intact() {
+        // "1234" is 4 digits — no leading-1 strip (length not > 10).
+        assert_eq!(normalize_addr("1234"), "1234");
+        // Exactly 10 digits — no leading-1 strip.
+        assert_eq!(normalize_addr("1234567890"), "1234567890");
+    }
+
+    #[test]
+    fn normalize_addr_handles_empty_and_non_numeric() {
+        assert_eq!(normalize_addr(""), "");
+        assert_eq!(normalize_addr("abc"), "");
+    }
+
+    #[test]
+    fn canonical_set_dedupes_and_sorts() {
+        let addrs = vec![
+            "5551234567".to_string(),
+            "+15551234567".to_string(),
+            "(555) 123-4567".to_string(),
+        ];
+        assert_eq!(canonical_set(&addrs), vec!["5551234567".to_string()]);
+    }
+
+    #[test]
+    fn canonical_set_drops_empty_addresses() {
+        let addrs = vec!["5551234567".to_string(), "".to_string(), "abc".to_string()];
+        assert_eq!(canonical_set(&addrs), vec!["5551234567".to_string()]);
+    }
+
+    #[test]
+    fn canonical_set_orders_results() {
+        let addrs = vec!["5559999999".to_string(), "5551111111".to_string()];
+        assert_eq!(
+            canonical_set(&addrs),
+            vec!["5551111111".to_string(), "5559999999".to_string()]
+        );
+    }
+
+    #[test]
+    fn is_reaction_bucket_merges_equal_canonical_sets() {
+        let a = cs(100, 3, &["+15551234567"], 1000, "hi", false, false);
+        let b = cs(101, 3, &["5551234567"], 2000, "Loved 'hi'", false, false);
+        assert!(is_reaction_bucket(&a, &b));
+    }
+
+    #[test]
+    fn is_reaction_bucket_rejects_different_addresses() {
+        let a = cs(100, 3, &["5551234567"], 1000, "hi", false, false);
+        let b = cs(101, 3, &["5559999999"], 2000, "yo", false, false);
+        assert!(!is_reaction_bucket(&a, &b));
+    }
+
+    #[test]
+    fn is_reaction_bucket_rejects_different_subids() {
+        // Same canonical set but different subIDs — different SIM cards.
+        let a = cs(100, 3, &["5551234567"], 1000, "hi", false, false);
+        let b = cs(101, 5, &["5551234567"], 2000, "hi", false, false);
+        assert!(!is_reaction_bucket(&a, &b));
+    }
+
+    #[test]
+    fn is_reaction_bucket_rejects_subid_minus_one() {
+        let a = cs(100, -1, &["5551234567"], 1000, "hi", false, false);
+        let b = cs(101, -1, &["5551234567"], 2000, "hi", false, false);
+        assert!(!is_reaction_bucket(&a, &b));
+        // Even one being -1 is a hard reject.
+        let c = cs(102, 3, &["5551234567"], 3000, "hi", false, false);
+        assert!(!is_reaction_bucket(&a, &c));
+    }
+
+    #[test]
+    fn is_reaction_bucket_rejects_strict_subset() {
+        // Subset clause is omitted at M7; one strictly contained in the
+        // other should NOT merge under primary-equality-only.
+        let a = cs(100, 3, &["5551111111", "5552222222"], 1000, "hi", false, false);
+        let b = cs(101, 3, &["5551111111"], 2000, "yo", false, false);
+        assert!(!is_reaction_bucket(&a, &b));
+    }
+
+    #[test]
+    fn merge_into_logical_passes_through_singletons() {
+        let raw = vec![
+            cs(100, 3, &["5551111111"], 1000, "a", false, false),
+            cs(200, 3, &["5552222222"], 2000, "b", false, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 2);
+        // Sorted by recency descending.
+        assert_eq!(logical[0].primary_thread_id, 200);
+        assert_eq!(logical[1].primary_thread_id, 100);
+        assert_eq!(logical[0].merged_thread_ids, vec![200]);
+        assert_eq!(logical[1].merged_thread_ids, vec![100]);
+    }
+
+    #[test]
+    fn merge_into_logical_collapses_pair() {
+        // Phase 1A Pair 1 shape: 1108 ↔ 1217, same addresses, same subID.
+        let raw = vec![
+            cs(1108, 3, &["+15551234567"], 5000, "original", false, false),
+            cs(1217, 3, &["5551234567"], 6000, "❤ to \"original\"", true, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 1);
+        let lc = &logical[0];
+        // Most-recent activity is 1217 (timestamp 6000) → primary.
+        assert_eq!(lc.primary_thread_id, 1217);
+        let mut merged = lc.merged_thread_ids.clone();
+        merged.sort();
+        assert_eq!(merged, vec![1108, 1217]);
+        assert_eq!(lc.subscription_id, 3);
+        assert_eq!(lc.last_message_preview, "❤ to \"original\"");
+        assert_eq!(lc.last_message_timestamp, 6000);
+        assert_eq!(lc.unread_count, 1);
+    }
+
+    #[test]
+    fn merge_into_logical_collapses_triple() {
+        // Phase 1A Pair 2 shape: 1048 ↔ 655 ↔ 1047, all same canonical set.
+        let raw = vec![
+            cs(1048, 3, &["5551111111", "5552222222"], 4000, "older", false, false),
+            cs(655,  3, &["5551111111", "5552222222"], 5000, "middle", true, false),
+            cs(1047, 3, &["5551111111", "5552222222"], 6000, "newest", true, true),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 1);
+        let lc = &logical[0];
+        assert_eq!(lc.primary_thread_id, 1047);
+        let mut merged = lc.merged_thread_ids.clone();
+        merged.sort();
+        assert_eq!(merged, vec![655, 1047, 1048]);
+        assert_eq!(lc.last_message_preview, "newest");
+        assert_eq!(lc.last_message_timestamp, 6000);
+        assert!(lc.has_attachments);
+        // Two of three threads were unread.
+        assert_eq!(lc.unread_count, 2);
+    }
+
+    #[test]
+    fn merge_into_logical_does_not_merge_across_subids() {
+        // Same addresses but different SIMs — must remain two logical convos.
+        let raw = vec![
+            cs(100, 3, &["5551111111"], 1000, "sim a", false, false),
+            cs(200, 5, &["5551111111"], 2000, "sim b", false, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 2);
+        assert!(logical.iter().all(|lc| lc.merged_thread_ids.len() == 1));
+    }
+
+    #[test]
+    fn merge_into_logical_does_not_merge_subid_minus_one() {
+        // Two threads with subID=-1, same addresses — heuristic rejects.
+        let raw = vec![
+            cs(100, -1, &["5551111111"], 1000, "a", false, false),
+            cs(200, -1, &["5551111111"], 2000, "b", false, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 2);
+    }
+
+    #[test]
+    fn merge_into_logical_unions_addresses() {
+        // Same canonical set but different formatting per thread.
+        let raw = vec![
+            cs(100, 3, &["+15551111111", "+15552222222"], 1000, "a", false, false),
+            cs(200, 3, &["5551111111", "5552222222"], 2000, "b", false, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 1);
+        assert_eq!(logical[0].addresses.len(), 2);
+        // First-seen formatting wins; 200 sorts as primary (newer), so its
+        // addresses come first in iteration during merge_group.
+        let canon = canonical_set(&logical[0].addresses);
+        assert_eq!(canon, vec!["5551111111".to_string(), "5552222222".to_string()]);
+    }
+
+    #[test]
+    fn merge_into_logical_output_sorted_by_recency() {
+        // One merged group (timestamp 5000), one standalone (timestamp 9000),
+        // one merged group (timestamp 1000). Expect order: 9000, 5000, 1000.
+        let raw = vec![
+            cs(10, 3, &["5551111111"], 1000, "old a", false, false),
+            cs(11, 3, &["5551111111"], 1500, "old b", false, false),
+            cs(20, 3, &["5552222222"], 9000, "lone", false, false),
+            cs(30, 3, &["5553333333"], 4000, "mid a", false, false),
+            cs(31, 3, &["5553333333"], 5000, "mid b", false, false),
+        ];
+        let logical = merge_into_logical(&raw);
+        assert_eq!(logical.len(), 3);
+        assert_eq!(logical[0].last_message_timestamp, 9000);
+        assert_eq!(logical[1].last_message_timestamp, 5000);
+        assert_eq!(logical[2].last_message_timestamp, 1500);
     }
 }

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -38,7 +38,7 @@ pub struct LogicalConversation {
     /// Whether the most recent message is an MMS with attachments.
     pub has_attachments: bool,
     /// Sum of underlying threads currently flagged unread.
-    #[allow(dead_code)] // Read at M11 (mark-as-read fan-out).
+    #[allow(dead_code)] // M11 deferred to v0.6.0+; field lights up with the unread display work.
     pub unread_count: usize,
 }
 

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -147,6 +147,22 @@ pub(crate) fn merge_into_logical(raw: &[ConversationSummary]) -> Vec<LogicalConv
 /// Build one `LogicalConversation` from a group of 2+ `ConversationSummary`
 /// values known to share the same canonical address-set and `sub_id`.
 fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
+    debug_assert!(
+        threads.len() >= 2,
+        "merge_group called with <2 threads; merge_into_logical guards this"
+    );
+    debug_assert!(
+        threads.iter().all(|cs| cs.sub_id == threads[0].sub_id),
+        "merge_group: all threads must share sub_id"
+    );
+    debug_assert!(
+        {
+            let canon = canonical_set(&threads[0].addresses);
+            threads.iter().all(|cs| canonical_set(&cs.addresses) == canon)
+        },
+        "merge_group: all threads must share canonical address-set"
+    );
+
     // Most-recently-active sibling becomes the primary, per the symmetric-
     // split tiebreak rule (Phase 1B: matches AOSP's outgoing-reply
     // canonicalization, so the echo lands on the threadId we passed).
@@ -155,6 +171,11 @@ fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
 
     let merged_thread_ids: Vec<i64> = threads.iter().map(|cs| cs.thread_id).collect();
     let subscription_id = primary.sub_id;
+
+    debug_assert!(
+        merged_thread_ids.contains(&primary.thread_id),
+        "merge_group: primary_thread_id must be in merged_thread_ids"
+    );
 
     // Address union deduplicated by canonical form, preserving the first-
     // seen original (carrier-formatted) string for display.
@@ -171,6 +192,14 @@ fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
 
     let unread_count = threads.iter().filter(|cs| cs.unread).count();
 
+    tracing::info!(
+          "merge_decision: primary={} merged={:?} sub_id={} canonical_addrs={:?}",
+          primary.thread_id,
+          merged_thread_ids,
+          subscription_id,
+          canonical_set(&primary.addresses)
+      );
+
     LogicalConversation {
         primary_thread_id: primary.thread_id,
         merged_thread_ids,
@@ -182,7 +211,6 @@ fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
         unread_count,
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -7,7 +7,7 @@
 //! See `Reaction Thread Splitting - Investigation and Fix Approach.md`
 //! for the design rationale and Phase 1B-validated heuristic.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use kdeconnect_dbus::plugins::ConversationSummary;
 
@@ -40,10 +40,19 @@ pub struct LogicalConversation {
     /// Sum of underlying threads currently flagged unread.
     #[allow(dead_code)] // M11 deferred to v0.6.0+; field lights up with the unread display work.
     pub unread_count: usize,
+    /// True when this conversation's underlying thread(s) participate in a
+    /// phone-side reaction-bucket group (per [`is_reaction_bucket`]).
+    /// Always true for merged entries (`merged_thread_ids.len() > 1`).
+    /// Computed per-entry on the merge-off path so the UI can mark threads
+    /// that *would* merge if the user enabled the feature, without
+    /// actually performing the merge.
+    pub is_split_candidate: bool,
 }
 
 impl LogicalConversation {
-    /// Wrap a single underlying conversation 1:1.
+    /// Wrap a single underlying conversation 1:1. Caller may overwrite
+    /// `is_split_candidate` based on whether the wrapped thread has a
+    /// reaction-bucket sibling in the broader raw-conversation set.
     pub fn from_single(cs: ConversationSummary) -> Self {
         Self {
             primary_thread_id: cs.thread_id,
@@ -54,6 +63,7 @@ impl LogicalConversation {
             last_message_timestamp: cs.timestamp,
             has_attachments: cs.has_attachments,
             unread_count: if cs.unread { 1 } else { 0 },
+            is_split_candidate: false,
         }
     }
 }
@@ -209,8 +219,33 @@ fn merge_group(mut threads: Vec<&ConversationSummary>) -> LogicalConversation {
         last_message_timestamp: primary.timestamp,
         has_attachments: primary.has_attachments,
         unread_count,
+        is_split_candidate: true,
     }
 }
+
+/// Returns the set of thread IDs that have at least one sibling satisfying
+/// [`is_reaction_bucket`] (same canonical address-set + same `sub_id`,
+/// excluding `sub_id == -1` and empty canonical sets per the heuristic).
+///
+/// Used by the merge-off path: when the user has disabled merging, we
+/// still want to show a marker on conversations that *would* merge if the
+/// feature were on. Computed once per `rederive_conversations` call.
+pub(crate) fn split_candidate_thread_ids(raw: &[ConversationSummary]) -> HashSet<i64> {
+    let mut groups: HashMap<(Vec<String>, i64), Vec<i64>> = HashMap::new();
+    for cs in raw {
+        let canon = canonical_set(&cs.addresses);
+        if cs.sub_id == -1 || canon.is_empty() {
+            continue;
+        }
+        groups.entry((canon, cs.sub_id)).or_default().push(cs.thread_id);
+    }
+    groups
+        .into_iter()
+        .filter(|(_, threads)| threads.len() > 1)
+        .flat_map(|(_, threads)| threads)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -341,6 +376,8 @@ mod tests {
         assert_eq!(logical[1].primary_thread_id, 100);
         assert_eq!(logical[0].merged_thread_ids, vec![200]);
         assert_eq!(logical[1].merged_thread_ids, vec![100]);
+        assert!(!logical[0].is_split_candidate);
+        assert!(!logical[1].is_split_candidate);
     }
 
     #[test]
@@ -362,6 +399,7 @@ mod tests {
         assert_eq!(lc.last_message_preview, "❤ to \"original\"");
         assert_eq!(lc.last_message_timestamp, 6000);
         assert_eq!(lc.unread_count, 1);
+        assert!(lc.is_split_candidate);
     }
 
     #[test]
@@ -441,5 +479,59 @@ mod tests {
         assert_eq!(logical[0].last_message_timestamp, 9000);
         assert_eq!(logical[1].last_message_timestamp, 5000);
         assert_eq!(logical[2].last_message_timestamp, 1500);
+    }
+
+    #[test]
+    fn split_candidate_thread_ids_finds_pair() {
+        let raw = vec![
+            cs(1108, 3, &["+15551234567"], 5000, "original", false, false),
+            cs(1217, 3, &["5551234567"], 6000, "❤ to \"original\"", true, false),
+            cs(999, 3, &["5559999999"], 7000, "lone", false, false),
+        ];
+        let candidates = split_candidate_thread_ids(&raw);
+        assert!(candidates.contains(&1108));
+        assert!(candidates.contains(&1217));
+        assert!(!candidates.contains(&999));
+    }
+
+    #[test]
+    fn split_candidate_thread_ids_skips_subid_minus_one() {
+        let raw = vec![
+            cs(100, -1, &["5551111111"], 1000, "a", false, false),
+            cs(200, -1, &["5551111111"], 2000, "b", false, false),
+        ];
+        let candidates = split_candidate_thread_ids(&raw);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn split_candidate_thread_ids_skips_empty_canonical() {
+        let raw = vec![
+            cs(100, 3, &[], 1000, "a", false, false),
+            cs(200, 3, &[], 2000, "b", false, false),
+        ];
+        let candidates = split_candidate_thread_ids(&raw);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn split_candidate_thread_ids_matches_merge_groups() {
+        // Same shape as merge_into_logical_collapses_triple; expect all 3 of
+        // the triple plus both of the pair to be candidates, and the
+        // standalone to be excluded.
+        let raw = vec![
+            cs(1108, 3, &["+15551234567"], 5000, "a", false, false),
+            cs(1217, 3, &["5551234567"], 6000, "b", false, false),
+            cs(1048, 3, &["5551111111", "5552222222"], 4000, "c", false, false),
+            cs(655, 3, &["5551111111", "5552222222"], 5000, "d", false, false),
+            cs(1047, 3, &["5551111111", "5552222222"], 6000, "e", false, false),
+            cs(999, 3, &["5559999999"], 7000, "lone", false, false),
+        ];
+        let candidates = split_candidate_thread_ids(&raw);
+        let mut actual: Vec<i64> = candidates.into_iter().collect();
+        actual.sort();
+        let mut expected: Vec<i64> = vec![1108, 1217, 1048, 655, 1047];
+        expected.sort();
+        assert_eq!(actual, expected);
     }
 }

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -7,13 +7,6 @@
 //! See `Reaction Thread Splitting - Investigation and Fix Approach.md`
 //! for the design rationale and Phase 1B-validated heuristic.
 
-// `merged_thread_ids`, `subscription_id`, `unread_count` are populated by
-// `merge_group` but not yet read; M8 (multi-thread subscription) and M11
-// (mark-as-read fan-out) light them up. `is_reaction_bucket` is the
-// pairwise-equivalent of the bucketing in `merge_into_logical`, kept as a
-// public predicate for tests and the future split-by-case reply rule.
-#![allow(dead_code)]
-
 use std::collections::{BTreeSet, HashMap};
 
 use kdeconnect_dbus::plugins::ConversationSummary;
@@ -33,6 +26,7 @@ pub struct LogicalConversation {
     pub merged_thread_ids: Vec<i64>,
     /// SIM subscription ID. Merge never crosses subID boundaries, so all
     /// threads in `merged_thread_ids` share this value.
+    #[allow(dead_code)] // Read at M9 (split-by-case reply rule).
     pub subscription_id: i64,
     /// Union of every underlying thread's address-set, deduplicated by
     /// canonical (digit-only) form. Original carrier formatting preserved
@@ -45,6 +39,7 @@ pub struct LogicalConversation {
     /// Whether the most recent message is an MMS with attachments.
     pub has_attachments: bool,
     /// Sum of underlying threads currently flagged unread.
+    #[allow(dead_code)] // Read at M11 (mark-as-read fan-out).
     pub unread_count: usize,
 }
 
@@ -101,6 +96,7 @@ pub(crate) fn canonical_set(addresses: &[String]) -> Vec<String> {
 /// pair was symmetric, and the conversation-summary-level body field is too
 /// sparse to drive the reaction-pattern check that the subset clause needs.
 /// Revisit once richer per-message context is available.
+#[allow(dead_code)] // Called at M9 (split-by-case reply rule); covered by tests today.
 pub(crate) fn is_reaction_bucket(a: &ConversationSummary, b: &ConversationSummary) -> bool {
     if a.sub_id == -1 || b.sub_id == -1 {
         return false;

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -1,0 +1,56 @@
+//! Logical conversation: wraps one-or-more underlying SMS thread IDs that
+//! represent the same user-perceived conversation.
+//!
+//! At M6 every `LogicalConversation` is a 1:1 wrapper around a single
+//! `ConversationSummary` (no merging). M7 introduces the reaction-bucket
+//! merge heuristic via `merge_into_logical`, which collapses split threads
+//! into a single `LogicalConversation` carrying multiple `merged_thread_ids`.
+
+#![allow(dead_code)] // M7 lights up 'merged_thread_ids', 'subscription_id', 'unread_count'
+
+use kdeconnect_dbus::plugins::ConversationSummary;
+
+/// A user-perceived conversation, possibly composed of multiple underlying
+/// SMS thread IDs that AOSP has split apart (e.g. by iOS reaction echoes
+/// arriving with slightly-different address-sets).
+#[derive(Debug, Clone)]
+pub struct LogicalConversation {
+    /// Thread ID used for `replyToConversation`. For a 1:1 wrapper this is
+    /// the underlying thread's ID; once merging is active, the split-by-case
+    /// reply rule picks the most-recently-active sibling within a symmetric
+    /// merge group.
+    pub primary_thread_id: i64,
+    /// All underlying thread IDs composing this logical conversation.
+    /// Always contains `primary_thread_id`. Single-element at M6.
+    pub merged_thread_ids: Vec<i64>,
+    /// SIM subscription ID. Merge never crosses subID boundaries, so all
+    /// threads in `merged_thread_ids` share this value.
+    pub subscription_id: i64,
+    /// Union of every underlying thread's address-set, deduplicated.
+    pub addresses: Vec<String>,
+    /// Preview of the most recent message body across all merged threads.
+    pub last_message_preview: String,
+    /// Unix-millis timestamp of the most recent message across all merged threads.
+    pub last_message_timestamp: i64,
+    /// Whether the most recent message is an MMS with attachments.
+    pub has_attachments: bool,
+    /// Number of underlying threads currently flagged unread. At M6 this is
+    /// `0` or `1` (1:1 wrapper); M7 sums across merged threads.
+    pub unread_count: usize,
+}
+
+impl LogicalConversation {
+    /// Wrap a single underlying conversation 1:1. M6's only construction path.
+    pub fn from_single(cs: ConversationSummary) -> Self {
+        Self {
+            primary_thread_id: cs.thread_id,
+            merged_thread_ids: vec![cs.thread_id],
+            subscription_id: cs.sub_id,
+            addresses: cs.addresses,
+            last_message_preview: cs.last_message,
+            last_message_timestamp: cs.timestamp,
+            has_attachments: cs.has_attachments,
+            unread_count: if cs.unread { 1 } else { 0 },
+        }
+    }
+}

--- a/cosmic-ext-connected/src/sms/logical.rs
+++ b/cosmic-ext-connected/src/sms/logical.rs
@@ -26,7 +26,6 @@ pub struct LogicalConversation {
     pub merged_thread_ids: Vec<i64>,
     /// SIM subscription ID. Merge never crosses subID boundaries, so all
     /// threads in `merged_thread_ids` share this value.
-    #[allow(dead_code)] // Read at M9 (split-by-case reply rule).
     pub subscription_id: i64,
     /// Union of every underlying thread's address-set, deduplicated by
     /// canonical (digit-only) form. Original carrier formatting preserved

--- a/cosmic-ext-connected/src/sms/mod.rs
+++ b/cosmic-ext-connected/src/sms/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod conversation_subscription;
 pub mod fetch;
+pub mod logical;
 pub mod send;
 pub mod store;
 pub mod views;

--- a/cosmic-ext-connected/src/sms/mod.rs
+++ b/cosmic-ext-connected/src/sms/mod.rs
@@ -3,6 +3,7 @@
 pub mod conversation_subscription;
 pub mod fetch;
 pub mod send;
+pub mod store;
 pub mod views;
 
 pub use conversation_subscription::*;

--- a/cosmic-ext-connected/src/sms/mod.rs
+++ b/cosmic-ext-connected/src/sms/mod.rs
@@ -9,4 +9,5 @@ pub mod views;
 pub use conversation_subscription::*;
 pub use fetch::*;
 pub use send::*;
+pub use store::*;
 pub use views::*;

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -89,9 +89,13 @@ pub struct SmsConversationStore {
     pub(crate) initial_load_complete: bool,
 
     // Active thread
-    pub(crate) loading_thread_id: Option<i64>,
     pub(crate) known_message_ids: HashSet<i32>,
     pub(crate) current_thread_id: Option<i64>,
+    /// All underlying SMS thread IDs composing the currently-open
+    /// `LogicalConversation`. Always contains `current_thread_id` (the primary)
+    /// when a conversation is open; empty otherwise. Drives the per-thread
+    /// message subscription fan-out in `subscriptions()`.
+    pub(crate) current_merged_thread_ids: Vec<i64>,
     pub(crate) current_thread_addresses: Option<Vec<String>>,
     pub(crate) current_thread_sub_id: Option<i64>,
     pub(crate) messages: Vec<SmsMessage>,
@@ -140,9 +144,9 @@ impl SmsConversationStore {
             message_sync_active: false,
             conversation_load_active: false,
             initial_load_complete: false,
-            loading_thread_id: None,
             known_message_ids: HashSet::new(),
             current_thread_id: None,
+            current_merged_thread_ids: Vec::new(),
             current_thread_addresses: None,
             current_thread_sub_id: None,
             messages: Vec::new(),
@@ -172,6 +176,26 @@ impl SmsConversationStore {
     /// Check if loading more messages (pagination)
     pub(crate) fn is_loading_more_messages(&self) -> bool {
         matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
+    }
+
+    /// Decide whether older messages are likely available for prefetch.
+    ///
+    /// For single-thread conversations, prefer the daemon-reported
+    /// `total_count` when available (`conversationLoaded` payload) and fall
+    /// back to a page-size heuristic otherwise. For merged conversations the
+    /// per-thread `total_count` is incomparable to the union
+    /// `self.messages.len()` (each subscription reports its own thread's
+    /// store size), so use heuristic-only — accurate-enough and avoids the
+    /// staggered-completion flicker where one subscription's small
+    /// `total_count` would falsely clamp `messages_has_more` to false.
+    fn compute_messages_has_more(&self, total_count: u64, page_size: usize) -> bool {
+        if self.current_merged_thread_ids.len() > 1 {
+            self.messages.len() >= page_size
+        } else if total_count > 0 && (self.messages.len() as u64) < total_count {
+            true
+        } else {
+            self.messages.len() >= page_size
+        }
     }
 
     /// Re-derive `conversations` from the raw cache through the merge
@@ -471,7 +495,7 @@ impl SmsConversationStore {
                     self.sms_loading_state = SmsLoadingState::Idle;
                 }
 
-                if self.current_thread_id == Some(thread_id) {
+                if self.current_merged_thread_ids.contains(&thread_id) {
                     // Filter out messages already known (safety net for signal cross-talk)
                     let older_msgs: Vec<_> = older_msgs
                         .into_iter()
@@ -654,8 +678,10 @@ impl SmsConversationStore {
 
             // Subscription-based message loading handlers
             Message::ConversationLoadStarted { thread_id } => {
-                // D-Bus request fired, subscription is now active
-                if self.current_thread_id == Some(thread_id) {
+                // D-Bus request fired, subscription is now active.
+                // Accept signals from any thread in the open merged set so
+                // every fanned-out subscription can flip the loading phase.
+                if self.current_merged_thread_ids.contains(&thread_id) {
                     tracing::debug!(
                         "Conversation {} load started, waiting for subscription signals",
                         thread_id
@@ -672,12 +698,15 @@ impl SmsConversationStore {
                 (cosmic::app::Task::none(), SmsReply::NoOp)
             }
             Message::ConversationMessageReceived { thread_id, message } => {
-                // Guard: Only process if still viewing this thread
-                if self.current_thread_id != Some(thread_id) {
+                // Guard: accept messages from any thread in the open merged set.
+                // Reactions split into bucket threads arrive on a different
+                // threadId than the primary; rejecting them here is the source
+                // of the orphaned-reactions UX bug from M7's smoke test.
+                if !self.current_merged_thread_ids.contains(&thread_id) {
                     tracing::debug!(
-                        "Ignoring message for thread {} (current: {:?})",
+                        "Ignoring message for thread {} (open merged set: {:?})",
                         thread_id,
-                        self.current_thread_id
+                        self.current_merged_thread_ids
                     );
                     return (cosmic::app::Task::none(), SmsReply::NoOp);
                 }
@@ -790,8 +819,10 @@ impl SmsConversationStore {
                 total_count,
             } => {
                 // Local store read complete - scroll to show messages while
-                // continuing to listen for phone response data
-                if self.current_thread_id != Some(thread_id) {
+                // continuing to listen for phone response data. Each fanned-out
+                // subscription emits its own ConversationStoreLoaded; accept any
+                // signal whose thread is in the open merged set.
+                if !self.current_merged_thread_ids.contains(&thread_id) {
                     return (cosmic::app::Task::none(), SmsReply::NoOp);
                 }
 
@@ -802,17 +833,12 @@ impl SmsConversationStore {
                     total_count
                 );
 
-                // Update pagination state
-                // Note: total_count from conversationLoaded reflects the LOCAL store count,
-                // which may be 0 or 1 after a reboot. Use a heuristic instead: if we've
-                // loaded a full page, there are likely more messages available.
+                // Update pagination state via helper (handles merged-set math).
                 self.messages_loaded_count = self.messages.len() as u32;
-                self.messages_has_more =
-                    if total_count > 0 && (self.messages.len() as u64) < total_count {
-                        true
-                    } else {
-                        self.messages.len() >= ctx.config.messages_per_page as usize
-                    };
+                self.messages_has_more = self.compute_messages_has_more(
+                    total_count,
+                    ctx.config.messages_per_page as usize,
+                );
 
                 // Scroll to bottom to show latest messages
                 if !self.messages.is_empty() {
@@ -830,39 +856,41 @@ impl SmsConversationStore {
                 thread_id,
                 total_count,
             } => {
-                // Guard: Only process if still viewing this thread
-                if self.current_thread_id != Some(thread_id) {
+                // Guard: accept completion signal from any thread in the open
+                // merged set. Each fanned-out subscription emits its own
+                // ConversationLoadComplete; step 3 will make the body
+                // idempotent so repeat arrivals don't redo work or break the
+                // messages_has_more math.
+                if !self.current_merged_thread_ids.contains(&thread_id) {
                     tracing::debug!(
-                        "Ignoring load complete for thread {} (current: {:?})",
+                        "Ignoring load complete for thread {} (open merged set: {:?})",
                         thread_id,
-                        self.current_thread_id
+                        self.current_merged_thread_ids
                     );
                     return (cosmic::app::Task::none(), SmsReply::NoOp);
                 }
 
+                let was_already_complete = self.initial_load_complete;
+
                 tracing::info!(
-                    "Conversation {} loading complete: {} messages loaded, {} total in conversation",
+                    "Conversation {} loading complete: {} messages loaded, {} total in conversation \
+                     (already_complete={})",
                     thread_id,
                     self.messages.len(),
-                    total_count
+                    total_count,
+                    was_already_complete
                 );
 
-                // Messages are already sorted during insertion, but sort again as safety
+                // Idempotent state refresh — safe to redo on each completion in
+                // a merged set (one ConversationLoadComplete per fanned-out
+                // subscription). Sort + pagination math + last_seen_sms all
+                // converge on the same final values regardless of arrival order.
                 self.messages.sort_by_key(|m| m.date);
-
-                // Update pagination state
-                // Note: total_count from conversationLoaded reflects the LOCAL store count,
-                // not the phone's total. Use a heuristic: if we've loaded a full page
-                // worth of messages, there are likely more available.
                 self.messages_loaded_count = self.messages.len() as u32;
-                self.messages_has_more =
-                    if total_count > 0 && (self.messages.len() as u64) < total_count {
-                        true
-                    } else {
-                        self.messages.len() >= ctx.config.messages_per_page as usize
-                    };
-
-                // Update last_seen_sms with the newest message timestamp
+                self.messages_has_more = self.compute_messages_has_more(
+                    total_count,
+                    ctx.config.messages_per_page as usize,
+                );
                 if let Some(newest) = self.messages.iter().map(|m| m.date).max() {
                     let current = self.last_seen_sms.get(&thread_id).copied();
                     if current.is_none() || current < Some(newest) {
@@ -870,13 +898,20 @@ impl SmsConversationStore {
                     }
                 }
 
-                // Clear sync indicator and loading state. The subscription keeps
-                // running to catch new messages (including sent message echoes).
+                // First-completion-only effects: clear loading indicators and
+                // snap to the latest message. Skipping these on repeat
+                // arrivals avoids yanking the user back to the bottom if a
+                // late-completing subscription fires after they've started
+                // scrolling. Note: subscriptions keep running to catch new
+                // messages (including sent-message echoes).
+                if was_already_complete {
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
                 self.message_sync_active = false;
                 self.initial_load_complete = true;
                 self.sms_loading_state = SmsLoadingState::Idle;
 
-                // Scroll to bottom if we loaded messages
                 if !self.messages.is_empty() {
                     return (
                         scrollable::snap_to(
@@ -1355,27 +1390,31 @@ impl SmsConversationStore {
             }
         }
 
-        // Per-thread message subscription (incremental message loading)
+        // Per-thread message subscription (incremental message loading).
+        // Fans out one subscription per underlying thread in the open
+        // `LogicalConversation` so reactions split into bucket threads load
+        // alongside the primary. iced keys subscriptions on the id tuple, so
+        // distinct `thread_id` values produce distinct running subscriptions.
         if self.conversation_load_active {
-            if let (Some(thread_id), Some(device_id)) =
-                (self.loading_thread_id, self.sms_device_id.clone())
-            {
+            if let Some(device_id) = self.sms_device_id.clone() {
                 let messages_per_page = config.messages_per_page;
-                subs.push(Subscription::run_with(
-                    (
-                        "conversation_messages",
-                        thread_id,
-                        device_id.clone(),
-                        messages_per_page,
-                    ),
-                    |(_, thread_id, device_id, messages_per_page)| {
-                        conversation_message_subscription(
-                            *thread_id,
+                for &thread_id in &self.current_merged_thread_ids {
+                    subs.push(Subscription::run_with(
+                        (
+                            "conversation_messages",
+                            thread_id,
                             device_id.clone(),
-                            *messages_per_page,
-                        )
-                    },
-                ));
+                            messages_per_page,
+                        ),
+                        |(_, thread_id, device_id, messages_per_page)| {
+                            conversation_message_subscription(
+                                *thread_id,
+                                device_id.clone(),
+                                *messages_per_page,
+                            )
+                        },
+                    ));
+                }
             }
         }
 

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -988,12 +988,21 @@ impl SmsConversationStore {
                         // the primary thread. See `reply_target` for the
                         // full rationale and Phase 1B citation.
                         let reply_target = self.reply_target(thread_id);
-                        tracing::info!(
-                            "Dispatching send_sms_async via replyToConversation \
-                             displayed_thread_id={} reply_target={}",
-                            thread_id,
-                            reply_target
+                        debug_assert!(
+                            self.logical_for(thread_id)
+                                .map(|lc| lc.merged_thread_ids.contains(&reply_target))
+                                .unwrap_or(reply_target == thread_id),
+                            "reply_target {} not in merged_thread_ids of logical for \
+                               displayed_thread_id {}",
+                            reply_target,
+                            thread_id
                         );
+                        tracing::info!(
+                              "Dispatching send_sms_async via replyToConversation \
+                               displayed_thread_id={} reply_target={}",
+                              thread_id,
+                              reply_target
+                          );
                         return (
                             cosmic::app::Task::perform(
                                 send_sms_async(

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -26,6 +26,7 @@ use kdeconnect_dbus::contacts::ContactLookup;
 use kdeconnect_dbus::plugins::{
     is_address_valid, ConversationSummary, MessageType, SmsMessage, OPTIMISTIC_MESSAGE_UID,
 };
+use crate::sms::logical::LogicalConversation;
 use kdeconnect_dbus::{normalize_phone_number, phone_suffix};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -75,7 +76,7 @@ pub struct SmsConversationStore {
     pub(crate) sms_device_name: Option<String>,
 
     // Conversation list
-    pub(crate) conversations: Vec<ConversationSummary>,
+    pub(crate) conversations: Vec<LogicalConversation>,
     pub(crate) sms_prefetch: Option<(String, Vec<ConversationSummary>)>,
     pub(crate) conversation_sync_active: bool,
     pub(crate) conversation_list_subscription_active: bool,
@@ -183,7 +184,7 @@ impl SmsConversationStore {
                     target_suffix == addr_suffix
                 })
             })
-            .map(|conv| conv.timestamp)
+            .map(|conv| conv.last_message_timestamp)
             .max()
     }
 
@@ -276,7 +277,7 @@ impl SmsConversationStore {
                         }
                     }
 
-                    self.conversations = convs;
+                    self.conversations = convs.into_iter().map(LogicalConversation::from_single).collect();
                     self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
                 }
                 // Background sync complete - clear sync indicator
@@ -317,11 +318,11 @@ impl SmsConversationStore {
                 if let Some(existing) = self
                     .conversations
                     .iter_mut()
-                    .find(|c| c.thread_id == conversation.thread_id)
+                    .find(|lc| lc.primary_thread_id == conversation.thread_id)
                 {
                     // Only update if the new conversation has a newer timestamp
-                    if conversation.timestamp > existing.timestamp {
-                        *existing = conversation.clone();
+                    if conversation.timestamp > existing.last_message_timestamp {
+                        *existing = LogicalConversation::from_single(conversation.clone());
                         tracing::debug!(
                             "Updated conversation thread {} (newer timestamp)",
                             conversation.thread_id
@@ -329,13 +330,13 @@ impl SmsConversationStore {
                     }
                 } else {
                     // Insert new conversation
-                    self.conversations.push(conversation.clone());
+                    self.conversations.push(LogicalConversation::from_single(conversation.clone()));
                     tracing::debug!("Added new conversation thread {}", conversation.thread_id);
                 }
 
                 // Re-sort by timestamp (newest first) and truncate
                 self.conversations
-                    .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
+                    .sort_by_key(|lc| std::cmp::Reverse(lc.last_message_timestamp));
                 self.conversations
                     .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
 
@@ -945,13 +946,13 @@ impl SmsConversationStore {
                             if let Some(conv) = self
                                 .conversations
                                 .iter_mut()
-                                .find(|c| c.thread_id == thread_id)
+                                .find(|lc| lc.primary_thread_id == thread_id)
                             {
-                                conv.last_message = sent_body;
-                                conv.timestamp = now_ms;
+                                conv.last_message_preview = sent_body;
+                                conv.last_message_timestamp = now_ms;
                             }
                             self.conversations
-                                .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
+                                .sort_by_key(|lc| std::cmp::Reverse(lc.last_message_timestamp));
 
                             // Insert optimistic message if echo hasn't already arrived.
                             // sms_sending_body is cleared by confirmed_send in

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -8,9 +8,10 @@
 
 #![allow(dead_code)] // stub methods; remove once call sites land
 
-use crate::app::{show_and_auto_close, DeviceInfo, LoadingPhase, Message, SmsLoadingState};
+use crate::app::{DeviceInfo, LoadingPhase, Message, SmsLoadingState};
 use crate::config::Config;
 use crate::fl;
+use crate::notifications::show_and_auto_close;
 use crate::sms::{
     conversation_list_subscription, fetch_older_messages_async, request_attachment_async,
     send_new_sms_async, send_sms_async, view_conversation_list, view_message_thread,

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -1,0 +1,97 @@
+//! `SmsConversationStore` — owns SMS conversation state, message caches,
+//! subscription orchestration, optimistic-send state, contacts, and SMS
+//! notification dedup.
+//!
+//! Skeleton only: types and method signatures defined per the C10 Spike
+//! Findings type-signature sketch. Method bodies are stubbed and nothing
+//! in `app.rs` references this module yet.
+
+#![allow(dead_code)] // M1 skeleton; first call sites land in M2
+
+use crate::app::{DeviceInfo, Message};
+use crate::config::Config;
+use cosmic::iced::Subscription;
+use cosmic::Element;
+use kdeconnect_dbus::plugins::SmsMessage;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use zbus::Connection;
+
+/// Read-only context the parent app passes to the store on each call.
+pub struct SmsCtx<'a> {
+    pub conn: &'a Arc<Mutex<Connection>>,
+    pub config: &'a Config,
+    pub devices: &'a [DeviceInfo],
+}
+
+/// Reply from the store back to the parent app describing app-level
+/// state changes the caller must apply.
+#[derive(Debug)]
+pub enum SmsReply {
+    /// SMS view is closing — caller should reset `view_mode` to `DevicePage`.
+    ExitSms,
+    /// Emit a transient status message via the app's normal status flow.
+    Status(String),
+    /// No app-level state change required.
+    NoOp,
+}
+
+/// Which SMS sub-view the parent app is rendering.
+#[derive(Debug, Clone, Copy)]
+pub enum SmsViewMode {
+    ConversationList,
+    MessageThread,
+    NewMessage,
+}
+
+pub struct SmsConversationStore;
+
+impl SmsConversationStore {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn update(
+        &mut self,
+        _msg: Message,
+        _ctx: &SmsCtx,
+    ) -> (cosmic::app::Task<Message>, SmsReply) {
+        unimplemented!()
+    }
+
+    pub fn view(&self, _mode: SmsViewMode) -> Element<'_, Message> {
+        unimplemented!()
+    }
+
+    pub fn subscriptions(&self, _config: &Config) -> Vec<Subscription<Message>> {
+        unimplemented!()
+    }
+
+    pub fn open(
+        &mut self,
+        _device_id: String,
+        _device_name: Option<String>,
+        _ctx: &SmsCtx,
+    ) -> cosmic::app::Task<Message> {
+        unimplemented!()
+    }
+
+    pub fn close(&mut self) {
+        unimplemented!()
+    }
+
+    pub fn handle_notification(
+        &mut self,
+        _device_id: String,
+        _message: SmsMessage,
+        _ctx: &SmsCtx,
+    ) -> cosmic::app::Task<Message> {
+        unimplemented!()
+    }
+}
+
+impl Default for SmsConversationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -196,11 +196,20 @@ impl SmsConversationStore {
         }
     }
 
-    /// Re-derive `conversations` from the raw cache through the merge
-    /// heuristic. Call after any mutation of `raw_conversations`. M13 will
-    /// thread the user toggle through the call site.
-    fn rederive_conversations(&mut self) {
-        self.conversations = merge_into_logical(&self.raw_conversations);
+    /// Re-derive `conversations` from the raw cache. Honors
+    /// `config.merge_reaction_threads`: runs `merge_into_logical` when on;
+    /// falls back to 1:1 `from_single` wrapping when off. Call after any
+    /// mutation of `raw_conversations`, or after the toggle changes.
+    pub(crate) fn rederive_conversations(&mut self, config: &Config) {
+        self.conversations = if config.merge_reaction_threads {
+            merge_into_logical(&self.raw_conversations)
+        } else {
+            self.raw_conversations
+                .iter()
+                .cloned()
+                .map(LogicalConversation::from_single)
+                .collect()
+        };
     }
 
     /// Find the `LogicalConversation` containing `thread_id` (whether as
@@ -346,7 +355,7 @@ impl SmsConversationStore {
                     }
 
                     self.raw_conversations = convs;
-                    self.rederive_conversations();
+                    self.rederive_conversations(ctx.config);
                     self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
                 }
                 // Background sync complete - clear sync indicator
@@ -410,7 +419,7 @@ impl SmsConversationStore {
                 self.raw_conversations
                     .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
 
-                self.rederive_conversations();
+                self.rederive_conversations(ctx.config);
 
                 // Update last_seen for notification deduplication
                 let current = self.last_seen_sms.get(&conversation.thread_id).copied();
@@ -1035,7 +1044,7 @@ impl SmsConversationStore {
                             }
                             self.raw_conversations
                                 .sort_by_key(|cs| std::cmp::Reverse(cs.timestamp));
-                            self.rederive_conversations();
+                            self.rederive_conversations(ctx.config);
 
                             // Insert optimistic message if echo hasn't already arrived.
                             // sms_sending_body is cleared by confirmed_send in

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -26,7 +26,7 @@ use kdeconnect_dbus::contacts::ContactLookup;
 use kdeconnect_dbus::plugins::{
     is_address_valid, ConversationSummary, MessageType, SmsMessage, OPTIMISTIC_MESSAGE_UID,
 };
-use crate::sms::logical::{merge_into_logical, LogicalConversation};
+use crate::sms::logical::{merge_into_logical, split_candidate_thread_ids, LogicalConversation};
 use kdeconnect_dbus::{normalize_phone_number, phone_suffix};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -198,16 +198,23 @@ impl SmsConversationStore {
 
     /// Re-derive `conversations` from the raw cache. Honors
     /// `config.merge_reaction_threads`: runs `merge_into_logical` when on;
-    /// falls back to 1:1 `from_single` wrapping when off. Call after any
-    /// mutation of `raw_conversations`, or after the toggle changes.
+    /// falls back to 1:1 `from_single` wrapping when off, and in the off
+    /// case marks each entry whose underlying thread has a reaction-bucket
+    /// sibling so the UI can surface "would-merge" indicators. Call after
+    /// any mutation of `raw_conversations`, or after the toggle changes.
     pub(crate) fn rederive_conversations(&mut self, config: &Config) {
         self.conversations = if config.merge_reaction_threads {
             merge_into_logical(&self.raw_conversations)
         } else {
+            let candidates = split_candidate_thread_ids(&self.raw_conversations);
             self.raw_conversations
                 .iter()
                 .cloned()
-                .map(LogicalConversation::from_single)
+                .map(|cs| {
+                    let mut lc = LogicalConversation::from_single(cs);
+                    lc.is_split_candidate = candidates.contains(&lc.primary_thread_id);
+                    lc
+                })
                 .collect()
         };
     }
@@ -1383,10 +1390,13 @@ impl SmsConversationStore {
     /// Render the active SMS sub-view.
     ///
     /// `status_message` is owned by the parent app and threaded through for
-    /// the message-thread view's send-confirmation/error banner.
+    /// the message-thread view's send-confirmation/error banner. `config`
+    /// supplies `merge_reaction_threads` to the conversation-list view so
+    /// the header toggle can show its current state.
     pub fn view<'a>(
         &'a self,
         mode: SmsViewMode,
+        config: &'a Config,
         status_message: Option<&'a str>,
     ) -> Element<'a, Message> {
         match mode {
@@ -1397,6 +1407,7 @@ impl SmsConversationStore {
                 contacts: &self.contacts,
                 loading_state: &self.sms_loading_state,
                 sync_active: self.conversation_sync_active,
+                merge_reaction_threads: config.merge_reaction_threads,
             }),
             SmsViewMode::MessageThread => {
                 let thread = view_message_thread(MessageThreadParams {

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -26,7 +26,7 @@ use kdeconnect_dbus::contacts::ContactLookup;
 use kdeconnect_dbus::plugins::{
     is_address_valid, ConversationSummary, MessageType, SmsMessage, OPTIMISTIC_MESSAGE_UID,
 };
-use crate::sms::logical::LogicalConversation;
+use crate::sms::logical::{merge_into_logical, LogicalConversation};
 use kdeconnect_dbus::{normalize_phone_number, phone_suffix};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -76,6 +76,10 @@ pub struct SmsConversationStore {
     pub(crate) sms_device_name: Option<String>,
 
     // Conversation list
+    /// Raw per-thread conversations from the daemon. Source of truth for the
+    /// derived `conversations` list — the toggle (M13) and any reaction-bucket
+    /// re-derivation works off this cache without re-fetching.
+    pub(crate) raw_conversations: Vec<ConversationSummary>,
     pub(crate) conversations: Vec<LogicalConversation>,
     pub(crate) sms_prefetch: Option<(String, Vec<ConversationSummary>)>,
     pub(crate) conversation_sync_active: bool,
@@ -128,6 +132,7 @@ impl SmsConversationStore {
         Self {
             sms_device_id: None,
             sms_device_name: None,
+            raw_conversations: Vec::new(),
             conversations: Vec::new(),
             sms_prefetch: None,
             conversation_sync_active: false,
@@ -167,6 +172,13 @@ impl SmsConversationStore {
     /// Check if loading more messages (pagination)
     pub(crate) fn is_loading_more_messages(&self) -> bool {
         matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
+    }
+
+    /// Re-derive `conversations` from the raw cache through the merge
+    /// heuristic. Call after any mutation of `raw_conversations`. M13 will
+    /// thread the user toggle through the call site.
+    fn rederive_conversations(&mut self) {
+        self.conversations = merge_into_logical(&self.raw_conversations);
     }
 
     /// Find the latest conversation timestamp for a phone number.
@@ -277,7 +289,8 @@ impl SmsConversationStore {
                         }
                     }
 
-                    self.conversations = convs.into_iter().map(LogicalConversation::from_single).collect();
+                    self.raw_conversations = convs;
+                    self.rederive_conversations();
                     self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
                 }
                 // Background sync complete - clear sync indicator
@@ -314,31 +327,34 @@ impl SmsConversationStore {
                     return (cosmic::app::Task::none(), SmsReply::NoOp);
                 }
 
-                // Update or insert conversation by thread_id
+                // Upsert into raw cache by underlying thread_id. Re-derive
+                // logical conversations after — incremental upsert on the
+                // logical list would create duplicate groups when a new
+                // thread joins an existing reaction-bucket merge.
                 if let Some(existing) = self
-                    .conversations
+                    .raw_conversations
                     .iter_mut()
-                    .find(|lc| lc.primary_thread_id == conversation.thread_id)
+                    .find(|cs| cs.thread_id == conversation.thread_id)
                 {
-                    // Only update if the new conversation has a newer timestamp
-                    if conversation.timestamp > existing.last_message_timestamp {
-                        *existing = LogicalConversation::from_single(conversation.clone());
+                    if conversation.timestamp > existing.timestamp {
+                        *existing = conversation.clone();
                         tracing::debug!(
                             "Updated conversation thread {} (newer timestamp)",
                             conversation.thread_id
                         );
                     }
                 } else {
-                    // Insert new conversation
-                    self.conversations.push(LogicalConversation::from_single(conversation.clone()));
+                    self.raw_conversations.push(conversation.clone());
                     tracing::debug!("Added new conversation thread {}", conversation.thread_id);
                 }
 
-                // Re-sort by timestamp (newest first) and truncate
-                self.conversations
-                    .sort_by_key(|lc| std::cmp::Reverse(lc.last_message_timestamp));
-                self.conversations
+                // Re-sort raw cache by timestamp (newest first) and truncate.
+                self.raw_conversations
+                    .sort_by_key(|cs| std::cmp::Reverse(cs.timestamp));
+                self.raw_conversations
                     .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
+
+                self.rederive_conversations();
 
                 // Update last_seen for notification deduplication
                 let current = self.last_seen_sms.get(&conversation.thread_id).copied();
@@ -938,21 +954,20 @@ impl SmsConversationStore {
                                 .map(|d| d.as_millis() as i64)
                                 .unwrap_or(0);
 
-                            // Clone before move into conversation preview
-                            let optimistic_body = sent_body.clone();
-
-                            // Update conversation list preview so it reflects the new message
-                            // when user navigates back
-                            if let Some(conv) = self
-                                .conversations
+                            // Update raw cache preview so an interim re-derive
+                            // (e.g. ConversationReceived for an unrelated thread)
+                            // can't clobber the optimistic update.
+                            if let Some(raw) = self
+                                .raw_conversations
                                 .iter_mut()
-                                .find(|lc| lc.primary_thread_id == thread_id)
+                                .find(|cs| cs.thread_id == thread_id)
                             {
-                                conv.last_message_preview = sent_body;
-                                conv.last_message_timestamp = now_ms;
+                                raw.last_message = sent_body.clone();
+                                raw.timestamp = now_ms;
                             }
-                            self.conversations
-                                .sort_by_key(|lc| std::cmp::Reverse(lc.last_message_timestamp));
+                            self.raw_conversations
+                                .sort_by_key(|cs| std::cmp::Reverse(cs.timestamp));
+                            self.rederive_conversations();
 
                             // Insert optimistic message if echo hasn't already arrived.
                             // sms_sending_body is cleared by confirmed_send in
@@ -960,7 +975,7 @@ impl SmsConversationStore {
                             // SmsSendResult — skip to avoid duplicate.
                             if self.sms_sending_body.is_some() {
                                 let optimistic = SmsMessage {
-                                    body: optimistic_body,
+                                    body: sent_body,
                                     addresses: self
                                         .current_thread_addresses
                                         .clone()

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -8,20 +8,32 @@
 
 #![allow(dead_code)] // stub methods; remove once call sites land
 
-use crate::app::{DeviceInfo, Message, SmsLoadingState};
+use crate::app::{show_and_auto_close, DeviceInfo, LoadingPhase, Message, SmsLoadingState};
 use crate::config::Config;
-use cosmic::iced::Subscription;
+use crate::fl;
+use crate::sms::{
+    fetch_older_messages_async, request_attachment_async, send_new_sms_async, send_sms_async,
+};
+use cosmic::iced::widget::scrollable;
+use cosmic::iced::{clipboard, Subscription};
+use cosmic::widget;
 use cosmic::Element;
 use kdeconnect_dbus::contacts::ContactLookup;
-use kdeconnect_dbus::plugins::{ConversationSummary, SmsMessage};
+use kdeconnect_dbus::plugins::{
+    is_address_valid, ConversationSummary, MessageType, SmsMessage, OPTIMISTIC_MESSAGE_UID,
+};
+use kdeconnect_dbus::{normalize_phone_number, phone_suffix};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use zbus::Connection;
 
 /// Read-only context the parent app passes to the store on each call.
+///
+/// `conn` is `Option` because the app may not yet have a D-Bus connection
+/// when an SMS message arrives; arms that need it guard internally.
 pub struct SmsCtx<'a> {
-    pub conn: &'a Arc<Mutex<Connection>>,
+    pub conn: Option<&'a Arc<Mutex<Connection>>>,
     pub config: &'a Config,
     pub devices: &'a [DeviceInfo],
 }
@@ -32,8 +44,15 @@ pub struct SmsCtx<'a> {
 pub enum SmsReply {
     /// SMS view is closing — caller should reset `view_mode` to `DevicePage`.
     ExitSms,
-    /// Emit a transient status message via the app's normal status flow.
+    /// Emit a transient status message (3s auto-clear).
     Status(String),
+    /// Set or clear `status_message` directly without auto-clear.
+    /// Used for sticky "Loading…" indicators that pair with explicit clear.
+    SetStatus(Option<String>),
+    /// Surface an error via the app's `error` field.
+    Error(String),
+    /// New-message send succeeded: set status_message + return to ConversationList.
+    NewMessageSent(String),
     /// No app-level state change required.
     NoOp,
 }
@@ -140,12 +159,1108 @@ impl SmsConversationStore {
         }
     }
 
+    /// Check if loading more messages (pagination)
+    pub(crate) fn is_loading_more_messages(&self) -> bool {
+        matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages)
+    }
+
+    /// Find the latest conversation timestamp for a phone number.
+    /// Uses suffix matching (last 10 digits) to handle format variations.
+    pub(crate) fn find_conversation_timestamp(&self, phone: &str) -> Option<i64> {
+        let phone_digits = normalize_phone_number(phone);
+        let target_suffix = phone_suffix(&phone_digits);
+
+        self.conversations
+            .iter()
+            .filter(|conv| {
+                conv.addresses.iter().any(|addr| {
+                    let addr_digits = normalize_phone_number(addr);
+                    let addr_suffix = phone_suffix(&addr_digits);
+                    target_suffix == addr_suffix
+                })
+            })
+            .map(|conv| conv.timestamp)
+            .max()
+    }
+
+    /// Generate contact suggestions with phone numbers sorted by conversation recency.
+    /// Returns (contact_name, phone_number) tuples, limited to max_suggestions.
+    pub(crate) fn generate_contact_suggestions(
+        &self,
+        query: &str,
+        max_suggestions: usize,
+    ) -> Vec<(String, String)> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        // Search for contacts matching the query (get more to account for multi-number expansion)
+        let matching_contacts = self.contacts.search_by_name(query, max_suggestions);
+
+        // Expand each contact into (name, phone, timestamp) entries
+        let mut entries: Vec<(String, String, Option<i64>)> = Vec::new();
+        for contact in matching_contacts {
+            for phone in &contact.phone_numbers {
+                let timestamp = self.find_conversation_timestamp(phone);
+                entries.push((contact.name.clone(), phone.clone(), timestamp));
+            }
+        }
+
+        // Sort by timestamp: most recent conversations first, then None (never contacted)
+        entries.sort_by(|a, b| match (&b.2, &a.2) {
+            (Some(ts_b), Some(ts_a)) => ts_b.cmp(ts_a), // Both have timestamps: recent first
+            (Some(_), None) => std::cmp::Ordering::Less, // b has timestamp, a doesn't: b first
+            (None, Some(_)) => std::cmp::Ordering::Greater, // a has timestamp, b doesn't: a first
+            (None, None) => std::cmp::Ordering::Equal,  // Neither has timestamp: keep order
+        });
+
+        // Take up to max_suggestions and drop the timestamp
+        entries
+            .into_iter()
+            .take(max_suggestions)
+            .map(|(name, phone, _)| (name, phone))
+            .collect()
+    }
+
+    /// Check if a phone number is already in the committed recipients list.
+    /// Uses suffix matching (last 10 digits) to handle format variations.
+    pub(crate) fn is_recipient_duplicate(&self, phone: &str) -> bool {
+        let normalized = normalize_phone_number(phone);
+        let suffix = phone_suffix(&normalized);
+        self.new_message_recipients.iter().any(|(_, existing)| {
+            let existing_normalized = normalize_phone_number(existing);
+            phone_suffix(&existing_normalized) == suffix
+        })
+    }
+
+    /// Generate contact suggestions filtered to exclude already-added recipients.
+    pub(crate) fn generate_contact_suggestions_filtered(
+        &self,
+        query: &str,
+        max: usize,
+    ) -> Vec<(String, String)> {
+        self.generate_contact_suggestions(query, max + self.new_message_recipients.len())
+            .into_iter()
+            .filter(|(_, phone)| !self.is_recipient_duplicate(phone))
+            .take(max)
+            .collect()
+    }
+
     pub fn update(
         &mut self,
-        _msg: Message,
-        _ctx: &SmsCtx,
+        msg: Message,
+        ctx: &SmsCtx,
     ) -> (cosmic::app::Task<Message>, SmsReply) {
-        unimplemented!()
+        match msg {
+            // === Batch 1: Conversation list ===
+            Message::ConversationsLoaded(convs) => {
+                // Slow path: full sync complete from phone (legacy batch loading)
+                tracing::info!(
+                    "Background sync complete: {} conversations (had {} cached)",
+                    convs.len(),
+                    self.conversations.len()
+                );
+                // Only update if we got conversations back
+                if !convs.is_empty() {
+                    // Pre-populate last_seen_sms to prevent false notifications
+                    // for messages that already exist in loaded conversations
+                    for conv in &convs {
+                        // Only update if we don't have a newer timestamp already
+                        let current = self.last_seen_sms.get(&conv.thread_id).copied();
+                        if current.is_none() || current < Some(conv.timestamp) {
+                            self.last_seen_sms.insert(conv.thread_id, conv.timestamp);
+                        }
+                    }
+
+                    self.conversations = convs;
+                    self.conversation_list_key = self.conversation_list_key.wrapping_add(1);
+                }
+                // Background sync complete - clear sync indicator
+                self.conversation_sync_active = false;
+                // Reset loading state if still loading
+                if matches!(
+                    self.sms_loading_state,
+                    SmsLoadingState::LoadingConversations(_)
+                ) {
+                    self.sms_loading_state = SmsLoadingState::Idle;
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::SmsPrefetchReady(device_id, conversations) => {
+                if !conversations.is_empty() {
+                    self.sms_prefetch = Some((device_id, conversations));
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            // Subscription-based conversation list loading handlers
+            Message::ConversationReceived {
+                device_id,
+                conversation,
+            } => {
+                // Guard: Only process if for current device
+                if self.sms_device_id.as_ref() != Some(&device_id) {
+                    tracing::debug!(
+                        "Ignoring conversation for device {} (current: {:?})",
+                        device_id,
+                        self.sms_device_id
+                    );
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                // Update or insert conversation by thread_id
+                if let Some(existing) = self
+                    .conversations
+                    .iter_mut()
+                    .find(|c| c.thread_id == conversation.thread_id)
+                {
+                    // Only update if the new conversation has a newer timestamp
+                    if conversation.timestamp > existing.timestamp {
+                        *existing = conversation.clone();
+                        tracing::debug!(
+                            "Updated conversation thread {} (newer timestamp)",
+                            conversation.thread_id
+                        );
+                    }
+                } else {
+                    // Insert new conversation
+                    self.conversations.push(conversation.clone());
+                    tracing::debug!("Added new conversation thread {}", conversation.thread_id);
+                }
+
+                // Re-sort by timestamp (newest first) and truncate
+                self.conversations
+                    .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
+                self.conversations
+                    .truncate(kdeconnect_dbus::plugins::MAX_CONVERSATIONS);
+
+                // Update last_seen for notification deduplication
+                let current = self.last_seen_sms.get(&conversation.thread_id).copied();
+                if current.is_none() || current < Some(conversation.timestamp) {
+                    self.last_seen_sms
+                        .insert(conversation.thread_id, conversation.timestamp);
+                }
+
+                // Transition from loading spinner to showing data (but keep sync indicator)
+                if matches!(
+                    self.sms_loading_state,
+                    SmsLoadingState::LoadingConversations(_)
+                ) {
+                    self.sms_loading_state = SmsLoadingState::Idle;
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::ConversationSyncStarted { device_id } => {
+                // Guard: Only process if for current device
+                if self.sms_device_id.as_ref() != Some(&device_id) {
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                tracing::debug!("Conversation sync started for device {}", device_id);
+                // Update loading phase to indicate we're waiting for signals
+                if matches!(
+                    self.sms_loading_state,
+                    SmsLoadingState::LoadingConversations(LoadingPhase::Connecting)
+                ) {
+                    self.sms_loading_state =
+                        SmsLoadingState::LoadingConversations(LoadingPhase::Requesting);
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::ConversationSyncComplete { device_id } => {
+                // Guard: Only process if for current device
+                if self.sms_device_id.as_ref() != Some(&device_id) {
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                tracing::info!(
+                    "Conversation sync indicator dismissed for device {}, {} conversations loaded",
+                    device_id,
+                    self.conversations.len()
+                );
+
+                // Clear sync indicator only. The subscription keeps running
+                // to catch new conversations while the SMS view is open.
+                self.conversation_sync_active = false;
+
+                // Only dismiss loading spinner if we have data to show.
+                // If conversations is empty, keep the spinner — the subscription
+                // continues listening and may receive conversations later.
+                // This prevents a false "no conversations" message on cold start
+                // when the phone is slow to respond.
+                if matches!(
+                    self.sms_loading_state,
+                    SmsLoadingState::LoadingConversations(_)
+                ) && !self.conversations.is_empty()
+                {
+                    self.sms_loading_state = SmsLoadingState::Idle;
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::ContactsLoaded(device_id, contacts) => {
+                // Only update if contacts are for the current SMS device
+                if self.sms_device_id.as_ref() == Some(&device_id) {
+                    tracing::info!(
+                        "Loaded {} contacts for device {}",
+                        contacts.len(),
+                        device_id
+                    );
+                    self.contacts = contacts;
+                } else {
+                    tracing::debug!(
+                        "Ignoring contacts for device {} (current: {:?})",
+                        device_id,
+                        self.sms_device_id
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::LoadMoreConversations => {
+                // Show 10 more conversations (up to total available)
+                self.conversations_displayed =
+                    (self.conversations_displayed + 10).min(self.conversations.len());
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::SmsError(err) => {
+                tracing::error!("SMS error: {}", err);
+                self.sms_loading_state = SmsLoadingState::Idle;
+                // Also clear subscription state on error
+                self.conversation_load_active = false;
+                self.conversation_list_subscription_active = false;
+                self.message_sync_active = false;
+                let status = format!("SMS error: {}", err);
+                (cosmic::app::Task::none(), SmsReply::Status(status))
+            }
+
+            // === Batch 2: Message thread / scroll / bubble ===
+            Message::OlderMessagesLoaded(
+                thread_id,
+                older_msgs,
+                has_more_heuristic,
+                total_count,
+            ) => {
+                // Only reset to Idle if we're currently loading more messages
+                if matches!(self.sms_loading_state, SmsLoadingState::LoadingMoreMessages) {
+                    self.sms_loading_state = SmsLoadingState::Idle;
+                }
+
+                if self.current_thread_id == Some(thread_id) {
+                    // Filter out messages already known (safety net for signal cross-talk)
+                    let older_msgs: Vec<_> = older_msgs
+                        .into_iter()
+                        .filter(|m| !self.known_message_ids.contains(&m.uid))
+                        .collect();
+                    for m in &older_msgs {
+                        self.known_message_ids.insert(m.uid);
+                    }
+
+                    if !older_msgs.is_empty() {
+                        let prepended_count = older_msgs.len();
+                        tracing::info!(
+                            "Prepending {} older messages to thread {} (had {}, total: {:?})",
+                            prepended_count,
+                            thread_id,
+                            self.messages.len(),
+                            total_count
+                        );
+
+                        // Prepend older messages (they come sorted oldest first)
+                        let mut combined = older_msgs;
+                        combined.append(&mut self.messages);
+                        self.messages = combined;
+
+                        // Update loaded count
+                        self.messages_loaded_count = self.messages.len() as u32;
+
+                        // Use total_count for accurate pagination if available,
+                        // otherwise fall back to heuristic
+                        self.messages_has_more = match total_count {
+                            Some(total) => (self.messages.len() as u64) < total,
+                            None => has_more_heuristic,
+                        };
+
+                        // Calculate scroll adjustment to preserve user's position
+                        // When we prepend messages, the content shifts down. We need to
+                        // scroll down by the estimated height of the prepended content.
+                        if let (Some(old_offset), Some(old_height)) = (
+                            self.scroll_offset_before_load.take(),
+                            self.content_height_before_load.take(),
+                        ) {
+                            // Estimate prepended content height (avg ~70px per message)
+                            const ESTIMATED_MSG_HEIGHT: f32 = 70.0;
+                            let prepended_height = prepended_count as f32 * ESTIMATED_MSG_HEIGHT;
+                            let new_content_height = old_height + prepended_height;
+                            let new_offset = old_offset + prepended_height;
+
+                            // Calculate relative offset (0.0 = top, 1.0 = bottom)
+                            let relative_y = (new_offset / new_content_height).clamp(0.0, 1.0);
+
+                            tracing::debug!(
+                                "Scroll adjustment: old_offset={:.1}, prepended_height={:.1}, new_relative_y={:.3}",
+                                old_offset, prepended_height, relative_y
+                            );
+
+                            return (
+                                scrollable::snap_to(
+                                    widget::Id::new("message-thread"),
+                                    scrollable::RelativeOffset {
+                                        x: Some(0.0),
+                                        y: Some(relative_y),
+                                    },
+                                ),
+                                SmsReply::NoOp,
+                            );
+                        }
+                    } else {
+                        tracing::info!("No older messages returned for thread {}", thread_id);
+                        // No more messages available
+                        self.messages_has_more = false;
+                        // Clear scroll state
+                        self.scroll_offset_before_load = None;
+                        self.content_height_before_load = None;
+                    }
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::MessageThreadScrolled(viewport) => {
+                // Prefetch older messages when user scrolls near the top
+                // Trigger when within 100 pixels of the top and not already loading
+                const PREFETCH_THRESHOLD_PX: f32 = 100.0;
+
+                let scroll_offset = viewport.absolute_offset().y;
+                let content_height = viewport.content_bounds().height;
+
+                if scroll_offset < PREFETCH_THRESHOLD_PX
+                    && self.messages_has_more
+                    && !self.is_loading_more_messages()
+                    && self.initial_load_complete
+                    && !self.messages.is_empty()
+                {
+                    tracing::debug!(
+                        "Prefetching older messages (scroll_y={:.1}px, content_height={:.1}px)",
+                        scroll_offset,
+                        content_height
+                    );
+
+                    // Store scroll state for position preservation after load
+                    self.scroll_offset_before_load = Some(scroll_offset);
+                    self.content_height_before_load = Some(content_height);
+
+                    // Trigger loading older messages (same logic as LoadMoreMessages)
+                    if let (Some(conn), Some(device_id), Some(thread_id)) = (
+                        ctx.conn,
+                        self.sms_device_id.as_ref(),
+                        self.current_thread_id,
+                    ) {
+                        self.sms_loading_state = SmsLoadingState::LoadingMoreMessages;
+                        let start_index = self.messages_loaded_count;
+                        let count = ctx.config.messages_per_page;
+
+                        return (
+                            cosmic::app::Task::perform(
+                                fetch_older_messages_async(
+                                    conn.clone(),
+                                    device_id.clone(),
+                                    thread_id,
+                                    start_index,
+                                    count,
+                                ),
+                                cosmic::Action::App,
+                            ),
+                            SmsReply::NoOp,
+                        );
+                    }
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::BubblePressStarted { uid, body } => {
+                self.pressed_bubble_uid = Some(uid);
+                self.pressed_bubble_body = Some(body);
+                self.show_copy_hint = false;
+                // Spawn delayed task - fires after 500ms to show hint
+                (
+                    cosmic::app::Task::perform(
+                        async {
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        },
+                        |_| cosmic::Action::App(Message::BubbleHintTimer),
+                    ),
+                    SmsReply::NoOp,
+                )
+            }
+
+            Message::BubblePressReleased => {
+                // Clear pressed state - cancels the long-press action
+                self.pressed_bubble_uid = None;
+                self.pressed_bubble_body = None;
+                self.show_copy_hint = false;
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::BubbleHintTimer => {
+                // 500ms elapsed - show "Hold to copy" hint and start 1.5s timer for actual copy
+                if self.pressed_bubble_uid.is_some() {
+                    self.show_copy_hint = true;
+                    return (
+                        cosmic::app::Task::perform(
+                            async {
+                                tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                            },
+                            |_| cosmic::Action::App(Message::BubbleLongPressComplete),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            Message::BubbleLongPressComplete => {
+                // 2s total elapsed - copy to clipboard if still pressed
+                if let Some(body) = self.pressed_bubble_body.take() {
+                    self.pressed_bubble_uid = None;
+                    self.show_copy_hint = false;
+                    return (clipboard::write(body), SmsReply::NoOp);
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            // Subscription-based message loading handlers
+            Message::ConversationLoadStarted { thread_id } => {
+                // D-Bus request fired, subscription is now active
+                if self.current_thread_id == Some(thread_id) {
+                    tracing::debug!(
+                        "Conversation {} load started, waiting for subscription signals",
+                        thread_id
+                    );
+                    // Update loading phase to indicate we're waiting for signals
+                    if matches!(
+                        self.sms_loading_state,
+                        SmsLoadingState::LoadingMessages(LoadingPhase::Connecting)
+                    ) {
+                        self.sms_loading_state =
+                            SmsLoadingState::LoadingMessages(LoadingPhase::Requesting);
+                    }
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::ConversationMessageReceived { thread_id, message } => {
+                // Guard: Only process if still viewing this thread
+                if self.current_thread_id != Some(thread_id) {
+                    tracing::debug!(
+                        "Ignoring message for thread {} (current: {:?})",
+                        thread_id,
+                        self.current_thread_id
+                    );
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                // Reconcile optimistic message: if this incoming sent message
+                // matches our optimistic insert's body within a 5-minute window,
+                // upgrade the optimistic entry in-place instead of inserting a duplicate.
+                if message.uid != OPTIMISTIC_MESSAGE_UID
+                    && message.message_type == MessageType::Sent
+                {
+                    if let Some(pos) = self.messages.iter().position(|m| {
+                        m.uid == OPTIMISTIC_MESSAGE_UID
+                            && m.message_type == MessageType::Sent
+                            && m.body == message.body
+                            && (message.date - m.date).unsigned_abs() < 300_000
+                    }) {
+                        tracing::info!(
+                            "Reconciling optimistic message with real uid={}",
+                            message.uid
+                        );
+                        self.messages[pos].uid = message.uid;
+                        self.messages[pos].date = message.date;
+                        self.known_message_ids.remove(&OPTIMISTIC_MESSAGE_UID);
+                        self.known_message_ids.insert(message.uid);
+                        self.sms_sending_body = None;
+                        return (cosmic::app::Task::none(), SmsReply::NoOp);
+                    }
+                }
+
+                // Deduplication: skip if already have this message
+                if self.known_message_ids.contains(&message.uid) {
+                    tracing::debug!(
+                        "Skipping duplicate message uid={} for thread {}",
+                        message.uid,
+                        thread_id
+                    );
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+                self.known_message_ids.insert(message.uid);
+
+                // Extract sub_id from first message (for MMS group messaging)
+                if self.current_thread_sub_id.is_none() {
+                    self.current_thread_sub_id = Some(message.sub_id);
+                    tracing::debug!("Set sub_id to {} for thread {}", message.sub_id, thread_id);
+                }
+
+                // Check if this confirms our pending sent message
+                let confirmed_send = self.sms_sending_body.is_some()
+                    && message.message_type == MessageType::Sent
+                    && self.sms_sending_body.as_deref() == Some(message.body.as_str());
+                if confirmed_send {
+                    tracing::info!("Confirmed delivery of sent message uid={}", message.uid);
+                    self.sms_sending_body = None;
+                }
+
+                // Insert message in sorted order by date
+                let insert_pos = self
+                    .messages
+                    .iter()
+                    .position(|m| m.date > message.date)
+                    .unwrap_or(self.messages.len());
+                self.messages.insert(insert_pos, message);
+
+                tracing::debug!(
+                    "Added message to thread {}, now have {} messages",
+                    thread_id,
+                    self.messages.len()
+                );
+
+                // Clear loading spinner after first message, show sync indicator instead
+                if matches!(self.sms_loading_state, SmsLoadingState::LoadingMessages(_)) {
+                    self.sms_loading_state = SmsLoadingState::Idle;
+                    self.message_sync_active = true;
+                }
+
+                // Scroll to bottom when a sent message is confirmed.
+                if confirmed_send {
+                    return (
+                        scrollable::snap_to(
+                            widget::Id::new("message-thread"),
+                            scrollable::RelativeOffset::END.into(),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+                // While the initial load is in flight, keep the newest message
+                // in view as messages stream in. Necessary because the daemon's
+                // worker emits `conversationLoaded` only when it actually
+                // fetched fresh phone data (see daemon's
+                // `addMessages()` → `conversationLoaded`); for cached-store
+                // hits the worker just emits per-message signals and finishes
+                // silently, so `ConversationStoreLoaded` and
+                // `ConversationLoadComplete` never fire and the scroll stays
+                // pinned at the top of an oldest-first list. Bounded by
+                // `initial_load_complete` so we don't yank a user reading
+                // older messages when a new SMS arrives later.
+                if !self.initial_load_complete {
+                    return (
+                        scrollable::snap_to(
+                            widget::Id::new("message-thread"),
+                            scrollable::RelativeOffset::END.into(),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::ConversationStoreLoaded {
+                thread_id,
+                total_count,
+            } => {
+                // Local store read complete - scroll to show messages while
+                // continuing to listen for phone response data
+                if self.current_thread_id != Some(thread_id) {
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                tracing::info!(
+                    "Local store loaded for thread {}: {} messages displayed, {} total in store",
+                    thread_id,
+                    self.messages.len(),
+                    total_count
+                );
+
+                // Update pagination state
+                // Note: total_count from conversationLoaded reflects the LOCAL store count,
+                // which may be 0 or 1 after a reboot. Use a heuristic instead: if we've
+                // loaded a full page, there are likely more messages available.
+                self.messages_loaded_count = self.messages.len() as u32;
+                self.messages_has_more =
+                    if total_count > 0 && (self.messages.len() as u64) < total_count {
+                        true
+                    } else {
+                        self.messages.len() >= ctx.config.messages_per_page as usize
+                    };
+
+                // Scroll to bottom to show latest messages
+                if !self.messages.is_empty() {
+                    return (
+                        scrollable::snap_to(
+                            widget::Id::new("message-thread"),
+                            scrollable::RelativeOffset::END.into(),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::ConversationLoadComplete {
+                thread_id,
+                total_count,
+            } => {
+                // Guard: Only process if still viewing this thread
+                if self.current_thread_id != Some(thread_id) {
+                    tracing::debug!(
+                        "Ignoring load complete for thread {} (current: {:?})",
+                        thread_id,
+                        self.current_thread_id
+                    );
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                tracing::info!(
+                    "Conversation {} loading complete: {} messages loaded, {} total in conversation",
+                    thread_id,
+                    self.messages.len(),
+                    total_count
+                );
+
+                // Messages are already sorted during insertion, but sort again as safety
+                self.messages.sort_by_key(|m| m.date);
+
+                // Update pagination state
+                // Note: total_count from conversationLoaded reflects the LOCAL store count,
+                // not the phone's total. Use a heuristic: if we've loaded a full page
+                // worth of messages, there are likely more available.
+                self.messages_loaded_count = self.messages.len() as u32;
+                self.messages_has_more =
+                    if total_count > 0 && (self.messages.len() as u64) < total_count {
+                        true
+                    } else {
+                        self.messages.len() >= ctx.config.messages_per_page as usize
+                    };
+
+                // Update last_seen_sms with the newest message timestamp
+                if let Some(newest) = self.messages.iter().map(|m| m.date).max() {
+                    let current = self.last_seen_sms.get(&thread_id).copied();
+                    if current.is_none() || current < Some(newest) {
+                        self.last_seen_sms.insert(thread_id, newest);
+                    }
+                }
+
+                // Clear sync indicator and loading state. The subscription keeps
+                // running to catch new messages (including sent message echoes).
+                self.message_sync_active = false;
+                self.initial_load_complete = true;
+                self.sms_loading_state = SmsLoadingState::Idle;
+
+                // Scroll to bottom if we loaded messages
+                if !self.messages.is_empty() {
+                    return (
+                        scrollable::snap_to(
+                            widget::Id::new("message-thread"),
+                            scrollable::RelativeOffset::END.into(),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+
+            // === Batch 3: Reply send + attachments + notification ===
+            Message::SmsComposeInput(text) => {
+                self.sms_compose_text = text;
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::SendSms => {
+                tracing::info!("SendSms triggered");
+                tracing::info!(
+                    "State: conn={}, device_id={:?}, thread_id={:?}, text_empty={}, sending={}",
+                    ctx.conn.is_some(),
+                    self.sms_device_id,
+                    self.current_thread_id,
+                    self.sms_compose_text.is_empty(),
+                    self.sms_sending
+                );
+                if let (Some(conn), Some(device_id), Some(thread_id)) = (
+                    ctx.conn,
+                    self.sms_device_id.as_ref(),
+                    self.current_thread_id,
+                ) {
+                    if !self.sms_compose_text.is_empty() && !self.sms_sending {
+                        let message_text = self.sms_compose_text.clone();
+                        self.sms_sending = true;
+                        self.sms_sending_body = Some(message_text.clone());
+                        tracing::info!(
+                            "Dispatching send_sms_async via replyToConversation for thread_id={}",
+                            thread_id
+                        );
+                        return (
+                            cosmic::app::Task::perform(
+                                send_sms_async(
+                                    conn.clone(),
+                                    device_id.clone(),
+                                    thread_id,
+                                    message_text,
+                                ),
+                                cosmic::Action::App,
+                            ),
+                            SmsReply::NoOp,
+                        );
+                    } else {
+                        tracing::warn!(
+                            "SendSms conditions not met: text_empty={}, sending={}",
+                            self.sms_compose_text.is_empty(),
+                            self.sms_sending
+                        );
+                    }
+                } else {
+                    tracing::warn!("SendSms missing required state");
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::SmsSendResult(result) => {
+                self.sms_sending = false;
+                match result {
+                    Ok(sent_body) => {
+                        tracing::info!("SMS sent successfully");
+                        self.sms_compose_text.clear();
+
+                        if let Some(thread_id) = self.current_thread_id {
+                            let now_ms = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis() as i64)
+                                .unwrap_or(0);
+
+                            // Clone before move into conversation preview
+                            let optimistic_body = sent_body.clone();
+
+                            // Update conversation list preview so it reflects the new message
+                            // when user navigates back
+                            if let Some(conv) = self
+                                .conversations
+                                .iter_mut()
+                                .find(|c| c.thread_id == thread_id)
+                            {
+                                conv.last_message = sent_body;
+                                conv.timestamp = now_ms;
+                            }
+                            self.conversations
+                                .sort_by_key(|c| std::cmp::Reverse(c.timestamp));
+
+                            // Insert optimistic message if echo hasn't already arrived.
+                            // sms_sending_body is cleared by confirmed_send in
+                            // ConversationMessageReceived if the echo arrived before
+                            // SmsSendResult — skip to avoid duplicate.
+                            if self.sms_sending_body.is_some() {
+                                let optimistic = SmsMessage {
+                                    body: optimistic_body,
+                                    addresses: self
+                                        .current_thread_addresses
+                                        .clone()
+                                        .unwrap_or_default(),
+                                    date: now_ms,
+                                    message_type: MessageType::Sent,
+                                    read: true,
+                                    thread_id,
+                                    uid: OPTIMISTIC_MESSAGE_UID,
+                                    sub_id: self.current_thread_sub_id.unwrap_or(-1),
+                                    attachments: vec![],
+                                };
+                                self.messages.push(optimistic);
+                                self.known_message_ids.insert(OPTIMISTIC_MESSAGE_UID);
+                                self.sms_sending_body = None;
+
+                                // No subscription restart needed — the message subscription
+                                // runs as long as the thread is open and will catch the
+                                // phone's echo naturally for optimistic reconciliation.
+
+                                return (
+                                    scrollable::snap_to(
+                                        widget::Id::new("message-thread"),
+                                        scrollable::RelativeOffset::END.into(),
+                                    ),
+                                    SmsReply::NoOp,
+                                );
+                            }
+                        }
+
+                        (cosmic::app::Task::none(), SmsReply::Status(fl!("sms-sent")))
+                    }
+                    Err(err) => {
+                        tracing::error!("SMS send error: {}", err);
+                        self.sms_sending_body = None;
+                        let status = format!("{}: {}", fl!("sms-failed"), err);
+                        (cosmic::app::Task::none(), SmsReply::Status(status))
+                    }
+                }
+            }
+
+            // Attachment messages
+            Message::OpenAttachment {
+                device_id,
+                device_name,
+                part_id,
+                unique_identifier,
+            } => {
+                // Check if KDE Connect has already cached this attachment
+                // KDE Connect daemon caches to ~/.cache/kdeconnect.daemon/<device-name>/
+                let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+                let cache_dir = std::path::PathBuf::from(home)
+                    .join(".cache/kdeconnect.daemon")
+                    .join(&device_name);
+                let cached_path = cache_dir.join(&unique_identifier);
+
+                if cached_path.exists() {
+                    // Already cached — open immediately
+                    let path_str = cached_path.to_string_lossy().to_string();
+                    return (
+                        cosmic::app::Task::perform(
+                            async move {
+                                let _ = tokio::process::Command::new("xdg-open")
+                                    .arg(&path_str)
+                                    .spawn();
+                            },
+                            |_| cosmic::Action::App(Message::ClearStatusMessage),
+                        ),
+                        SmsReply::NoOp,
+                    );
+                }
+
+                // Not cached — request from phone via D-Bus
+                if let Some(conn) = ctx.conn {
+                    return (
+                        cosmic::app::Task::perform(
+                            request_attachment_async(
+                                conn.clone(),
+                                device_id,
+                                device_name,
+                                part_id,
+                                unique_identifier,
+                            ),
+                            cosmic::Action::App,
+                        ),
+                        SmsReply::SetStatus(Some(fl!("loading-attachment"))),
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::AttachmentReady(file_path) => {
+                (
+                    cosmic::app::Task::perform(
+                        async move {
+                            let _ = tokio::process::Command::new("xdg-open")
+                                .arg(&file_path)
+                                .spawn();
+                        },
+                        |_| cosmic::Action::App(Message::ClearStatusMessage),
+                    ),
+                    SmsReply::SetStatus(None),
+                )
+            }
+            Message::AttachmentError(err) => {
+                tracing::error!("Attachment error: {}", err);
+                (
+                    cosmic::app::Task::none(),
+                    SmsReply::Status(fl!("attachment-failed")),
+                )
+            }
+
+            Message::SmsNotificationReceived(device_id, message) => {
+                // Freshness check: only notify for messages received within the last 30 seconds.
+                // This prevents false notifications when fetching historical messages and handles
+                // cross-process deduplication (COSMIC spawns multiple applet instances).
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let message_age_ms = now_ms - message.date;
+                if message_age_ms > 30_000 {
+                    // Message is older than 30 seconds, skip notification
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                // Check if we've already seen this message (deduplication)
+                let last_seen = self.last_seen_sms.get(&message.thread_id).copied();
+                if last_seen.is_some() && last_seen >= Some(message.date) {
+                    // Already seen this message or an older one
+                    return (cosmic::app::Task::none(), SmsReply::NoOp);
+                }
+
+                // Update last seen timestamp for this thread
+                self.last_seen_sms.insert(message.thread_id, message.date);
+
+                // Capture config settings
+                let show_sender = ctx.config.sms_notification_show_sender;
+                let show_content = ctx.config.sms_notification_show_content;
+                let timeout_ms = ctx.config.notification_timeout_secs * 1000;
+                let message_body = message.body.clone();
+
+                // Resolve sender name: use cached contacts if available, otherwise load from disk
+                let cached_sender_name = if show_sender {
+                    let has_cached_contacts = self.sms_device_id.as_ref() == Some(&device_id)
+                        && !self.contacts.is_empty();
+                    if has_cached_contacts {
+                        Some(self.contacts.get_group_display_name(&message.addresses, 3))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let addresses = message.addresses.clone();
+
+                // Show notification asynchronously
+                (
+                    cosmic::app::Task::perform(
+                        async move {
+                            // Build summary: resolve sender name if needed and not already cached
+                            let summary = if show_sender {
+                                let sender_name = match cached_sender_name {
+                                    Some(name) => name,
+                                    None => {
+                                        let contacts = ContactLookup::load_for_device(&device_id).await;
+                                        contacts.get_group_display_name(&addresses, 3)
+                                    }
+                                };
+                                fl!("sms-notification-title-from", sender = sender_name)
+                            } else {
+                                fl!("sms-notification-title")
+                            };
+
+                            let body = if show_content {
+                                message_body
+                            } else {
+                                fl!("sms-notification-body-hidden")
+                            };
+
+                            let mut notification = notify_rust::Notification::new();
+                            notification
+                                .summary(&summary)
+                                .body(&body)
+                                .icon("phone-symbolic")
+                                .appname("Connected")
+                                .timeout(notify_rust::Timeout::Never);
+                            show_and_auto_close(notification, timeout_ms, "SMS").await;
+                        },
+                        |_| cosmic::Action::App(Message::RefreshDevices),
+                    ),
+                    SmsReply::NoOp,
+                )
+            }
+
+            // === Batch 4: New-message compose ===
+            Message::NewMessageRecipientInput(text) => {
+                self.contact_suggestions = self.generate_contact_suggestions_filtered(&text, 10);
+                self.new_message_recipient_input = text;
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::NewMessageBodyInput(text) => {
+                self.new_message_body = text;
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::AddManualRecipient => {
+                let input = self.new_message_recipient_input.trim().to_string();
+                if is_address_valid(&input) && !self.is_recipient_duplicate(&input) {
+                    let display = self.contacts.get_name_or_number(&input);
+                    self.new_message_recipients.push((display, input));
+                    self.new_message_recipient_input.clear();
+                    self.contact_suggestions.clear();
+                    return (
+                        widget::text_input::focus(widget::Id::new("new-message-recipient")),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::RemoveRecipient(index) => {
+                if index < self.new_message_recipients.len() {
+                    self.new_message_recipients.remove(index);
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::SelectContact(_name, phone) => {
+                if !self.is_recipient_duplicate(&phone) {
+                    let display = self.contacts.get_name_or_number(&phone);
+                    self.new_message_recipients.push((display, phone));
+                    self.new_message_recipient_input.clear();
+                    self.contact_suggestions.clear();
+                    return (
+                        widget::text_input::focus(widget::Id::new("new-message-recipient")),
+                        SmsReply::NoOp,
+                    );
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::SendNewMessage => {
+                if let (Some(conn), Some(device_id)) = (ctx.conn, self.sms_device_id.as_ref()) {
+                    if !self.new_message_recipients.is_empty()
+                        && !self.new_message_body.is_empty()
+                        && !self.new_message_sending
+                    {
+                        let recipients: Vec<String> = self
+                            .new_message_recipients
+                            .iter()
+                            .map(|(_, phone)| phone.clone())
+                            .collect();
+                        let message = self.new_message_body.clone();
+                        self.new_message_sending = true;
+                        return (
+                            cosmic::app::Task::perform(
+                                send_new_sms_async(
+                                    conn.clone(),
+                                    device_id.clone(),
+                                    recipients,
+                                    message,
+                                ),
+                                cosmic::Action::App,
+                            ),
+                            SmsReply::NoOp,
+                        );
+                    }
+                }
+                (cosmic::app::Task::none(), SmsReply::NoOp)
+            }
+            Message::NewMessageSendResult(result) => {
+                self.new_message_sending = false;
+                match &result {
+                    Ok(msg) => {
+                        tracing::info!("New message send result: {}", msg);
+                        // Clear fields and return to conversation list
+                        let success_msg = msg.clone();
+                        self.new_message_recipients.clear();
+                        self.new_message_recipient_input.clear();
+                        self.new_message_body.clear();
+                        // Enable subscription to catch the new conversation when the phone
+                        // syncs back. The subscription listens over a longer window than a
+                        // one-shot fetch, giving the phone time to process the send and
+                        // emit a conversationCreated signal.
+                        if self.sms_device_id.is_some() {
+                            self.conversation_list_subscription_active = true;
+                            self.conversation_sync_active = true;
+                        }
+                        (
+                            cosmic::app::Task::none(),
+                            SmsReply::NewMessageSent(success_msg),
+                        )
+                    }
+                    Err(err) => {
+                        tracing::error!("New message send error: {}", err);
+                        (
+                            cosmic::app::Task::none(),
+                            SmsReply::Status(format!("Send failed: {}", err)),
+                        )
+                    }
+                }
+            }
+
+            // Catch-all: non-SMS variants and SMS variants not yet migrated
+            // Phase C will narrow `app.rs` delegation to the migrated subset,
+            // so this arm only fires for genuine routing mistakes after M3.
+            _ => unreachable!("non-SMS Message routed to SmsConversationStore"),
+        }
     }
 
     pub fn view(&self, _mode: SmsViewMode) -> Element<'_, Message> {

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -12,8 +12,11 @@ use crate::app::{show_and_auto_close, DeviceInfo, LoadingPhase, Message, SmsLoad
 use crate::config::Config;
 use crate::fl;
 use crate::sms::{
-    fetch_older_messages_async, request_attachment_async, send_new_sms_async, send_sms_async,
+    conversation_list_subscription, fetch_older_messages_async, request_attachment_async,
+    send_new_sms_async, send_sms_async, view_conversation_list, view_message_thread,
+    view_new_message, ConversationListParams, MessageThreadParams, NewMessageParams,
 };
+use crate::subscriptions::conversation_message_subscription;
 use cosmic::iced::widget::scrollable;
 use cosmic::iced::{clipboard, Subscription};
 use cosmic::widget;
@@ -1263,12 +1266,103 @@ impl SmsConversationStore {
         }
     }
 
-    pub fn view(&self, _mode: SmsViewMode) -> Element<'_, Message> {
-        unimplemented!()
+    /// Render the active SMS sub-view.
+    ///
+    /// `status_message` is owned by the parent app and threaded through for
+    /// the message-thread view's send-confirmation/error banner.
+    pub fn view<'a>(
+        &'a self,
+        mode: SmsViewMode,
+        status_message: Option<&'a str>,
+    ) -> Element<'a, Message> {
+        match mode {
+            SmsViewMode::ConversationList => view_conversation_list(ConversationListParams {
+                device_name: self.sms_device_name.as_deref(),
+                conversations: &self.conversations,
+                conversations_displayed: self.conversations_displayed,
+                contacts: &self.contacts,
+                loading_state: &self.sms_loading_state,
+                sync_active: self.conversation_sync_active,
+            }),
+            SmsViewMode::MessageThread => {
+                let thread = view_message_thread(MessageThreadParams {
+                    device_id: self.sms_device_id.as_deref().unwrap_or(""),
+                    device_name: self.sms_device_name.as_deref().unwrap_or(""),
+                    thread_addresses: self.current_thread_addresses.as_deref(),
+                    messages: &self.messages,
+                    contacts: &self.contacts,
+                    loading_state: &self.sms_loading_state,
+                    sms_compose_text: &self.sms_compose_text,
+                    sms_sending: self.sms_sending,
+                    sync_active: self.message_sync_active,
+                    pressed_bubble_uid: self.pressed_bubble_uid,
+                    show_copy_hint: self.show_copy_hint,
+                    status_message,
+                });
+                // popup_container uses Shrink height internally, which sets a
+                // compression flag on iced's layout limits. Under compression,
+                // the flex layout processes all children in document order and a
+                // scrollable's intrinsic content size consumes all available
+                // height, leaving 0 for the compose row below it. A Fixed height
+                // wrapper is the only way to clear that flag (Fill doesn't);
+                // the value is capped to popup_container's 1000px max.
+                widget::container(thread)
+                    .height(cosmic::iced::Length::Fixed(10_000.0))
+                    .width(cosmic::iced::Length::Fill)
+                    .into()
+            }
+            SmsViewMode::NewMessage => view_new_message(NewMessageParams {
+                recipients: &self.new_message_recipients,
+                recipient_input: &self.new_message_recipient_input,
+                body: &self.new_message_body,
+                sending: self.new_message_sending,
+                contact_suggestions: &self.contact_suggestions,
+            }),
+        }
     }
 
-    pub fn subscriptions(&self, _config: &Config) -> Vec<Subscription<Message>> {
-        unimplemented!()
+    /// SMS-state-driven subscriptions: conversation-list refresh and the
+    /// per-thread message subscription. The unconditional SMS/call notification
+    /// subscriptions stay in `app.rs::subscription()` because they're gated on
+    /// device reachability + config, not store state.
+    pub fn subscriptions(&self, config: &Config) -> Vec<Subscription<Message>> {
+        let mut subs: Vec<Subscription<Message>> = Vec::new();
+
+        // Conversation list subscription (incremental loading + background sync)
+        if self.conversation_list_subscription_active {
+            if let Some(device_id) = self.sms_device_id.clone() {
+                subs.push(Subscription::run_with(
+                    ("conversation_list", device_id.clone()),
+                    |(_, device_id)| conversation_list_subscription(device_id.clone()),
+                ));
+            }
+        }
+
+        // Per-thread message subscription (incremental message loading)
+        if self.conversation_load_active {
+            if let (Some(thread_id), Some(device_id)) =
+                (self.loading_thread_id, self.sms_device_id.clone())
+            {
+                let messages_per_page = config.messages_per_page;
+                subs.push(Subscription::run_with(
+                    (
+                        "conversation_messages",
+                        thread_id,
+                        device_id.clone(),
+                        messages_per_page,
+                    ),
+                    |(_, thread_id, device_id, messages_per_page)| {
+                        conversation_message_subscription(
+                            *thread_id,
+                            device_id.clone(),
+                            *messages_per_page,
+                        )
+                    },
+                ));
+            }
+        }
+
+        subs
     }
 
     pub fn open(

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -97,7 +97,6 @@ pub struct SmsConversationStore {
     /// message subscription fan-out in `subscriptions()`.
     pub(crate) current_merged_thread_ids: Vec<i64>,
     pub(crate) current_thread_addresses: Option<Vec<String>>,
-    pub(crate) current_thread_sub_id: Option<i64>,
     pub(crate) messages: Vec<SmsMessage>,
     pub(crate) sms_loading_state: SmsLoadingState,
     pub(crate) contacts: ContactLookup,
@@ -148,7 +147,6 @@ impl SmsConversationStore {
             current_thread_id: None,
             current_merged_thread_ids: Vec::new(),
             current_thread_addresses: None,
-            current_thread_sub_id: None,
             messages: Vec::new(),
             sms_loading_state: SmsLoadingState::Idle,
             contacts: ContactLookup::default(),
@@ -203,6 +201,40 @@ impl SmsConversationStore {
     /// thread the user toggle through the call site.
     fn rederive_conversations(&mut self) {
         self.conversations = merge_into_logical(&self.raw_conversations);
+    }
+
+    /// Find the `LogicalConversation` containing `thread_id` (whether as
+    /// primary or as a merged sibling). Returns `None` for unknown thread
+    /// IDs. Centralizes the membership lookup pattern from M8.
+    fn logical_for(&self, thread_id: i64) -> Option<&LogicalConversation> {
+        self.conversations
+            .iter()
+            .find(|lc| lc.merged_thread_ids.contains(&thread_id))
+    }
+
+    /// Pick the threadId to pass to `replyToConversation` for the displayed
+    /// thread, per the Phase 1B-validated split-by-case rule.
+    ///
+    /// - **Symmetric merge** (canonical address-sets equal across the merged
+    ///   group — the only case M7's primary-equality heuristic produces) →
+    ///   redirect to `primary_thread_id` (most-recently-active sibling
+    ///   within `subID`). Matches AOSP's outgoing-reply canonicalization
+    ///   so the echo lands where we expect, and bypasses AOSP's per-bucket
+    ///   processing that produced recipient-side duplicate delivery on
+    ///   Pair 4 (1055↔58, captured 2026-05-02).
+    /// - **Asymmetric / subset clause** (untested across 6 captured Phase 1
+    ///   pairs; reintroduced if/when the subset clause returns in v0.6.0+)
+    ///   → preserve the displayed thread ID. Conservative until field data
+    ///   confirms the redirect is address-safe under subset shapes.
+    /// - **Non-merged or unknown** → return the displayed thread ID.
+    ///
+    /// See `Reaction Thread Splitting - Investigation and Fix Approach.md`
+    /// "Layer C-specific risks" for the full table.
+    pub(crate) fn reply_target(&self, displayed_thread_id: i64) -> i64 {
+        self.logical_for(displayed_thread_id)
+            .filter(|lc| lc.merged_thread_ids.len() > 1)
+            .map(|lc| lc.primary_thread_id)
+            .unwrap_or(displayed_thread_id)
     }
 
     /// Find the latest conversation timestamp for a phone number.
@@ -747,12 +779,6 @@ impl SmsConversationStore {
                 }
                 self.known_message_ids.insert(message.uid);
 
-                // Extract sub_id from first message (for MMS group messaging)
-                if self.current_thread_sub_id.is_none() {
-                    self.current_thread_sub_id = Some(message.sub_id);
-                    tracing::debug!("Set sub_id to {} for thread {}", message.sub_id, thread_id);
-                }
-
                 // Check if this confirms our pending sent message
                 let confirmed_send = self.sms_sending_body.is_some()
                     && message.message_type == MessageType::Sent
@@ -948,16 +974,23 @@ impl SmsConversationStore {
                         let message_text = self.sms_compose_text.clone();
                         self.sms_sending = true;
                         self.sms_sending_body = Some(message_text.clone());
+                        // Apply the split-by-case rule: for symmetric merges
+                        // (every merged set under M7's heuristic) redirect to
+                        // the primary thread. See `reply_target` for the
+                        // full rationale and Phase 1B citation.
+                        let reply_target = self.reply_target(thread_id);
                         tracing::info!(
-                            "Dispatching send_sms_async via replyToConversation for thread_id={}",
-                            thread_id
+                            "Dispatching send_sms_async via replyToConversation \
+                             displayed_thread_id={} reply_target={}",
+                            thread_id,
+                            reply_target
                         );
                         return (
                             cosmic::app::Task::perform(
                                 send_sms_async(
                                     conn.clone(),
                                     device_id.clone(),
-                                    thread_id,
+                                    reply_target,
                                     message_text,
                                 ),
                                 cosmic::Action::App,
@@ -1009,6 +1042,17 @@ impl SmsConversationStore {
                             // ConversationMessageReceived if the echo arrived before
                             // SmsSendResult — skip to avoid duplicate.
                             if self.sms_sending_body.is_some() {
+                                // Source sub_id from the LogicalConversation
+                                // populated at fetch time, not the lazy
+                                // first-message field that M9 retired. The
+                                // value is the same SIM property; sourcing
+                                // it here closes the pre-first-message
+                                // window where the optimistic stamp would
+                                // have fallen back to -1.
+                                let sub_id = self
+                                    .logical_for(thread_id)
+                                    .map(|lc| lc.subscription_id)
+                                    .unwrap_or(-1);
                                 let optimistic = SmsMessage {
                                     body: sent_body,
                                     addresses: self
@@ -1020,7 +1064,7 @@ impl SmsConversationStore {
                                     read: true,
                                     thread_id,
                                     uid: OPTIMISTIC_MESSAGE_UID,
-                                    sub_id: self.current_thread_sub_id.unwrap_or(-1),
+                                    sub_id,
                                     attachments: vec![],
                                 };
                                 self.messages.push(optimistic);

--- a/cosmic-ext-connected/src/sms/store.rs
+++ b/cosmic-ext-connected/src/sms/store.rs
@@ -2,17 +2,19 @@
 //! subscription orchestration, optimistic-send state, contacts, and SMS
 //! notification dedup.
 //!
-//! Skeleton only: types and method signatures defined per the C10 Spike
-//! Findings type-signature sketch. Method bodies are stubbed and nothing
-//! in `app.rs` references this module yet.
+//! M2: 35 SMS-touching fields migrated from `ConnectApplet`. Method bodies
+//! remain stubbed; `app.rs` accesses fields directly via `self.sms.<field>`.
+//! Field encapsulation tightens as method bodies fill in (M3–M5).
 
-#![allow(dead_code)] // M1 skeleton; first call sites land in M2
+#![allow(dead_code)] // stub methods; remove once call sites land
 
-use crate::app::{DeviceInfo, Message};
+use crate::app::{DeviceInfo, Message, SmsLoadingState};
 use crate::config::Config;
 use cosmic::iced::Subscription;
 use cosmic::Element;
-use kdeconnect_dbus::plugins::SmsMessage;
+use kdeconnect_dbus::contacts::ContactLookup;
+use kdeconnect_dbus::plugins::{ConversationSummary, SmsMessage};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use zbus::Connection;
@@ -44,11 +46,98 @@ pub enum SmsViewMode {
     NewMessage,
 }
 
-pub struct SmsConversationStore;
+pub struct SmsConversationStore {
+    // Active SMS device
+    pub(crate) sms_device_id: Option<String>,
+    pub(crate) sms_device_name: Option<String>,
+
+    // Conversation list
+    pub(crate) conversations: Vec<ConversationSummary>,
+    pub(crate) sms_prefetch: Option<(String, Vec<ConversationSummary>)>,
+    pub(crate) conversation_sync_active: bool,
+    pub(crate) conversation_list_subscription_active: bool,
+    pub(crate) message_sync_active: bool,
+    pub(crate) conversation_load_active: bool,
+    pub(crate) initial_load_complete: bool,
+
+    // Active thread
+    pub(crate) loading_thread_id: Option<i64>,
+    pub(crate) known_message_ids: HashSet<i32>,
+    pub(crate) current_thread_id: Option<i64>,
+    pub(crate) current_thread_addresses: Option<Vec<String>>,
+    pub(crate) current_thread_sub_id: Option<i64>,
+    pub(crate) messages: Vec<SmsMessage>,
+    pub(crate) sms_loading_state: SmsLoadingState,
+    pub(crate) contacts: ContactLookup,
+    pub(crate) conversation_list_key: u32,
+    pub(crate) conversations_displayed: usize,
+
+    // Reply compose / send
+    pub(crate) sms_compose_text: String,
+    pub(crate) sms_sending: bool,
+    pub(crate) sms_sending_body: Option<String>,
+
+    // Message pagination / scroll preservation
+    pub(crate) messages_loaded_count: u32,
+    pub(crate) messages_has_more: bool,
+    pub(crate) scroll_offset_before_load: Option<f32>,
+    pub(crate) content_height_before_load: Option<f32>,
+
+    // New-message compose
+    pub(crate) new_message_recipients: Vec<(String, String)>,
+    pub(crate) new_message_recipient_input: String,
+    pub(crate) new_message_body: String,
+    pub(crate) new_message_sending: bool,
+    pub(crate) contact_suggestions: Vec<(String, String)>,
+
+    // SMS notification deduplication
+    pub(crate) last_seen_sms: HashMap<i64, i64>,
+
+    // Long-press copy
+    pub(crate) pressed_bubble_uid: Option<i32>,
+    pub(crate) pressed_bubble_body: Option<String>,
+    pub(crate) show_copy_hint: bool,
+}
 
 impl SmsConversationStore {
     pub fn new() -> Self {
-        Self
+        Self {
+            sms_device_id: None,
+            sms_device_name: None,
+            conversations: Vec::new(),
+            sms_prefetch: None,
+            conversation_sync_active: false,
+            conversation_list_subscription_active: false,
+            message_sync_active: false,
+            conversation_load_active: false,
+            initial_load_complete: false,
+            loading_thread_id: None,
+            known_message_ids: HashSet::new(),
+            current_thread_id: None,
+            current_thread_addresses: None,
+            current_thread_sub_id: None,
+            messages: Vec::new(),
+            sms_loading_state: SmsLoadingState::Idle,
+            contacts: ContactLookup::default(),
+            conversation_list_key: 0,
+            conversations_displayed: 10,
+            sms_compose_text: String::new(),
+            sms_sending: false,
+            sms_sending_body: None,
+            messages_loaded_count: 0,
+            messages_has_more: true,
+            scroll_offset_before_load: None,
+            content_height_before_load: None,
+            new_message_recipients: Vec::new(),
+            new_message_recipient_input: String::new(),
+            new_message_body: String::new(),
+            new_message_sending: false,
+            contact_suggestions: Vec::new(),
+            last_seen_sms: HashMap::new(),
+            pressed_bubble_uid: None,
+            pressed_bubble_body: None,
+            show_copy_hint: false,
+        }
     }
 
     pub fn update(

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -1,6 +1,6 @@
 //! SMS view components for conversation list and message threads.
 
-use crate::app::{LoadingPhase, Message, SmsLoadingState};
+use crate::app::{LoadingPhase, Message, SettingKey, SmsLoadingState};
 use crate::fl;
 use crate::views::helpers::format_timestamp;
 use base64::Engine;
@@ -151,6 +151,11 @@ pub struct ConversationListParams<'a> {
     pub loading_state: &'a SmsLoadingState,
     /// Whether background sync is active (syncing conversations from phone)
     pub sync_active: bool,
+    /// Current value of `config.merge_reaction_threads`. Drives the header
+    /// toggle's icon + tooltip; also controls whether per-entry merge
+    /// markers can appear (no markers when merging is off because no
+    /// `LogicalConversation` will have `merged_thread_ids.len() > 1`).
+    pub merge_reaction_threads: bool,
 }
 
 /// Render the SMS conversation list view.
@@ -190,9 +195,31 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
     .gap(sp.space_xxxs)
     .padding(sp.space_xxs);
 
+    let (merge_toggle_icon, merge_toggle_tooltip) = if params.merge_reaction_threads {
+        (
+            "io.github.nwxnw.cosmic-ext-connected-merged-symbolic",
+            fl!("merge-toggle-on-tooltip"),
+        )
+    } else {
+        (
+            "io.github.nwxnw.cosmic-ext-connected-split-symbolic",
+            fl!("merge-toggle-off-tooltip"),
+        )
+    };
+    let merge_toggle_btn = widget::tooltip(
+        widget::button::icon(widget::icon::from_name(merge_toggle_icon))
+            .class(cosmic::theme::Button::Link)
+            .on_press(Message::ToggleSetting(SettingKey::MergeReactionThreads)),
+        text::caption(merge_toggle_tooltip),
+        widget::tooltip::Position::Bottom,
+    )
+    .gap(sp.space_xxxs)
+    .padding(sp.space_xxs);
+
     let header = applet::padded_control(
         header_row
             .push(widget::space::horizontal())
+            .push(merge_toggle_btn)
             .push(new_msg_btn),
     );
 
@@ -257,13 +284,33 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
                         .into()
                 };
 
+            let marker_glyph: Option<&str> = if conv.merged_thread_ids.len() > 1 {
+                Some("io.github.nwxnw.cosmic-ext-connected-merged-symbolic")
+            } else if conv.is_split_candidate {
+                Some("io.github.nwxnw.cosmic-ext-connected-split-symbolic")
+            } else {
+                None
+            };
+
+            let snippet_row: Element<Message> = if let Some(glyph) = marker_glyph {
+                row![
+                    widget::icon::from_name(glyph).size(12),
+                    snippet_element,
+                ]
+                .spacing(sp.space_xxxs)
+                .align_y(Alignment::Center)
+                .into()
+            } else {
+                snippet_element
+            };
+
             let conv_row = applet::menu_button(
                 row![
                     widget::container(
                         column![
                             text::body(display_name)
                                 .wrapping(cosmic::iced::widget::text::Wrapping::None),
-                            snippet_element,
+                            snippet_row,
                         ]
                         .spacing(2),
                     )

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -708,6 +708,7 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
     // Message input
     let message_input = widget::text_input(fl!("type-message"), params.body)
         .on_input(Message::NewMessageBodyInput)
+        .on_submit(|_| Message::SendNewMessage)
         .width(Length::Fill);
 
     // Send button — enabled when at least one recipient and body is non-empty
@@ -733,9 +734,9 @@ pub fn view_new_message(params: NewMessageParams<'_>) -> Element<'_, Message> {
 
     column![
         header,
-        chips_section,
         recipient_row,
         suggestions_section,
+        chips_section,
         applet::padded_control(message_input),
         send_row,
         widget::space::vertical(),

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -12,9 +12,10 @@ use cosmic::widget::{self, text};
 use cosmic::Element;
 use kdeconnect_dbus::contacts::ContactLookup;
 use kdeconnect_dbus::plugins::{
-    is_address_valid, Attachment, ConversationSummary, MessageType, SmsMessage,
+    is_address_valid, Attachment, MessageType, SmsMessage,
     OPTIMISTIC_MESSAGE_UID,
 };
+use crate::sms::logical::LogicalConversation;
 
 // --- Helper functions for loading state ---
 
@@ -144,7 +145,7 @@ fn view_attachment<'a>(
 /// Parameters for the conversation list view.
 pub struct ConversationListParams<'a> {
     pub device_name: Option<&'a str>,
-    pub conversations: &'a [ConversationSummary],
+    pub conversations: &'a [LogicalConversation],
     pub conversations_displayed: usize,
     pub contacts: &'a ContactLookup,
     pub loading_state: &'a SmsLoadingState,
@@ -225,11 +226,11 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
             .take(params.conversations_displayed)
         {
             let display_name = params.contacts.get_group_display_name(&conv.addresses, 3);
-            let date_str = format_timestamp(conv.timestamp);
+            let date_str = format_timestamp(conv.last_message_timestamp);
 
             // Build snippet: show attachment indicator if needed
             let snippet_element: Element<Message> =
-                if conv.has_attachments && conv.last_message.is_empty() {
+                if conv.has_attachments && conv.last_message_preview.is_empty() {
                     // MMS with only attachments (no text body)
                     row![
                         widget::icon::from_name("mail-attachment-symbolic").size(14),
@@ -241,7 +242,7 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
                     .into()
                 } else if conv.has_attachments {
                     // MMS with both text and attachments
-                    let snippet = conv.last_message.chars().take(50).collect::<String>();
+                    let snippet = conv.last_message_preview.chars().take(50).collect::<String>();
                     row![
                         widget::icon::from_name("mail-attachment-symbolic").size(14),
                         text::caption(snippet).wrapping(cosmic::iced::widget::text::Wrapping::None),
@@ -250,7 +251,7 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
                     .align_y(Alignment::Center)
                     .into()
                 } else {
-                    let snippet = conv.last_message.chars().take(50).collect::<String>();
+                    let snippet = conv.last_message_preview.chars().take(50).collect::<String>();
                     text::caption(snippet)
                         .wrapping(cosmic::iced::widget::text::Wrapping::None)
                         .into()
@@ -274,7 +275,7 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
                 .spacing(sp.space_xxs)
                 .align_y(Alignment::Center),
             )
-            .on_press(Message::OpenConversation(conv.thread_id));
+            .on_press(Message::OpenConversation(conv.primary_thread_id));
 
             conv_column = conv_column.push(conv_row);
         }

--- a/cosmic-ext-connected/src/sms/views.rs
+++ b/cosmic-ext-connected/src/sms/views.rs
@@ -293,8 +293,14 @@ pub fn view_conversation_list(params: ConversationListParams<'_>) -> Element<'_,
             };
 
             let snippet_row: Element<Message> = if let Some(glyph) = marker_glyph {
+                let marker_icon = widget::icon::from_name(glyph).size(14).icon()
+                    .class(cosmic::theme::Svg::custom(|theme| {
+                        cosmic::iced::widget::svg::Style {
+                            color: Some(theme.cosmic().accent_text_color().into()),
+                        }
+                    }));
                 row![
-                    widget::icon::from_name(glyph).size(12),
+                    marker_icon,
                     snippet_element,
                 ]
                 .spacing(sp.space_xxxs)

--- a/cosmic-ext-connected/src/views/settings.rs
+++ b/cosmic-ext-connected/src/views/settings.rs
@@ -50,6 +50,13 @@ pub fn view_settings(config: &Config) -> Element<'_, Message> {
                 .toggler(config.forward_notifications, move |_| {
                     Message::ToggleSetting(SettingKey::ForwardNotifications)
                 }),
+        )
+        .add(
+            settings::item::builder(fl!("settings-sms-merge-reaction-threads"))
+                .description(fl!("settings-sms-merge-reaction-threads-desc"))
+                .toggler(config.merge_reaction_threads, move |_| {
+                    Message::ToggleSetting(SettingKey::MergeReactionThreads)
+                }),
         );
 
     // Navigation to notification settings sub-page

--- a/data/icons/hicolor/scalable/apps/io.github.nwxnw.cosmic-ext-connected-merged-symbolic.svg
+++ b/data/icons/hicolor/scalable/apps/io.github.nwxnw.cosmic-ext-connected-merged-symbolic.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 -960 960 960" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="m296-160-56-56 200-200v-269L337-582l-57-57 200-200 201 201-57 57-104-104v301L296-160Zm368 1L536-286l57-57 127 128-56 56Z"/>
+</svg>

--- a/data/icons/hicolor/scalable/apps/io.github.nwxnw.cosmic-ext-connected-split-symbolic.svg
+++ b/data/icons/hicolor/scalable/apps/io.github.nwxnw.cosmic-ext-connected-split-symbolic.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 -960 960 960" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M190-160V-640L90-640L240-840L390-640L290-640V-160ZM670-160V-640L570-640L720-840L870-640L770-640V-160Z"/>
+</svg>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Connected will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **SMS: merged-conversation indicators and SMS-view toggle.** Conversations that Connected has merged from multiple phone-side threads (the iOS-reaction-over-SMS case) now show a small marker on the conversation list. A new toggle in the SMS view header switches between the merged and split views in one click — useful if the heuristic misfires for a particular conversation, or just to see what the phone's underlying thread structure looks like. The toggle shares state with the new SMS settings option.
+- **SMS: split-thread indicators when merging is off.** When the merge toggle is off, conversations whose underlying threads are reaction-bucket siblings on the phone now show a passive marker on the conversation list. At-a-glance visibility into which conversations would merge if the feature were enabled.
+
+### Fixed
+- **SMS: iOS reaction-over-SMS no longer splits a conversation across multiple threads.** Threads with identical participants on the same SIM are merged into one logical conversation, and replies route through the merged set. **As a side effect, replying on these conversations now delivers a single copy to recipients — previously, AOSP canonicalization across the split could produce duplicate delivery.** A toggle in SMS settings lets you disable merging if it misfires on your carrier/device combo.
+
+### Changed
+- **Internal refactor:** SMS conversation state extracted from the main applet module into a dedicated `SmsConversationStore`. No user-visible change on its own; enables the reaction-thread merging feature above and unlocks targeted SMS tests in v0.6.0.
+
 ## [0.4.0] - 2026-05-01
 
 ### Added

--- a/docs/SMS.md
+++ b/docs/SMS.md
@@ -72,7 +72,7 @@ Merging precondition (`is_reaction_bucket`):
 
 Each `LogicalConversation` carries:
 
-- `primary_thread_id` — the most-recently-active sibling within the merged set; used as the reply target (M9) and notification dedup key (M12).
+- `primary_thread_id` — the most-recently-active sibling within the merged set; used as the reply target.
 - `merged_thread_ids` — all underlying threadIds composing this logical conversation. Always contains `primary_thread_id`. Single-element for non-merged.
 
 Opening a merged conversation fans out the message subscription: one `conversation_message_subscription` per underlying threadId, each firing its own `requestConversation` and emitting `ConversationMessageReceived` for its own thread. Signal handlers accept any thread in the open `current_merged_thread_ids` set rather than only the primary.
@@ -81,6 +81,29 @@ Multi-subscription completion semantics:
 
 - `ConversationLoadComplete` is idempotent. Math (sort, `messages_has_more`, `last_seen_sms`) always runs; loading-state clear and scroll-to-bottom snap fire only on the first arrival. Late completions silently refresh stats so a slow-completing subscription can't yank the user back to bottom.
 - `messages_has_more` math forces a heuristic-only branch when `current_merged_thread_ids.len() > 1`, since per-thread `total_count` is incomparable to the union `messages.len()`.
+
+### Reply target rule
+
+When the user sends a reply into a conversation, Connected picks the threadId to pass to `replyToConversation` based on the merge state of the open conversation:
+
+- **Symmetric merge** (canonical address-sets equal across the merged group — the case M7's primary-equality heuristic produces): redirect to `primary_thread_id`. This matches AOSP's outgoing-reply canonicalization, so the echo lands on the threadId Connected passed and the optimistic-send reconciliation can complete cleanly. As a side effect, the redirect bypasses AOSP's per-bucket processing that would otherwise produce **recipient-side duplicate delivery** — the recipient receives one copy instead of two.
+- **Asymmetric / subset clause** (untested across captured pairs; reintroduced if/when the subset clause returns to the merge heuristic): preserve the displayed thread's threadId. Conservative until field data confirms the redirect is address-safe under subset shapes. The branch is dormant under M7's primary-equality heuristic — every merged set is symmetric by construction — so production paths today take the symmetric arm exclusively.
+- **Non-merged or unknown thread**: pass the displayed threadId through unchanged.
+
+The duplicate-delivery side effect is empirically locked. Pre-merge behavior on a known reaction-bucket pair (Pair 4 captured 2026-05-02) reproduced two-copy delivery to the recipient. Under the redirect, the same pair delivers one copy. The redirect is therefore a corrective fix for a recipient-visible bug, not just a display-merge convenience.
+
+The reply-target rule applies only when merging is on. With merging off (see "Per-entry markers and SMS-view toggle" below), Connected sends to whichever underlying thread the user opened. Replying into the non-canonical sibling thread of a reaction-bucket pair will reproduce the AOSP-canonicalization symptoms — the echo arrives on the canonical primary instead of the displayed thread, the optimistic-send "Sending…" indicator can stay pinned, and the recipient may receive duplicate copies. This is documented behavior gated behind the user opt-out, not a regression.
+
+### Per-entry markers and SMS-view toggle
+
+The SMS conversation list shows a small marker on rows that participate in a reaction-bucket group. Two glyphs:
+
+- **Merge marker** (visible when the merge toggle is on): rows whose `LogicalConversation.merged_thread_ids.len() > 1` show a converging-Y glyph next to the message preview. Indicates "this conversation merges multiple phone-side threads."
+- **Split marker** (visible when the merge toggle is off): rows whose underlying thread has at least one reaction-bucket sibling in the conversation list show a parallel-arrows glyph next to the message preview. Indicates "this conversation has a sibling thread on the phone; turning the merge toggle on would combine them."
+
+A header toggle in the SMS view (between the conversation-list title and the new-message button) switches between merged and split states. The toggle uses the same iconography as the per-entry markers — converging-Y when merging is on, parallel-arrows when off — and dispatches the same `Message::ToggleSetting(SettingKey::MergeReactionThreads)` as the M13 settings option, so the two surfaces share state automatically. Toggling either one updates the other, and the toggle state persists across applet restarts.
+
+The merge-off path uses the same `is_reaction_bucket` predicate as the merge-on path, so any pair the merge logic *would* combine also appears as split-marker entries when the user has merging off. When the v0.6.0+ subset clause returns to the heuristic, both surfaces pick it up automatically without further coordination.
 
 ### Older Message Loading
 
@@ -103,6 +126,8 @@ On success:
 - the conversation preview updates immediately with the latest body and timestamp
 - an optimistic sent bubble is inserted into the open thread
 - the long-lived message subscription reconciles that optimistic entry when the phone echoes back the real sent message
+
+For merged conversations, optimistic-send reconciliation matches by `OPTIMISTIC_MESSAGE_UID` + body + 5-minute window with no thread-id filter, so an echo arriving on a sibling thread within `merged_thread_ids` still upgrades the optimistic bubble in place. Combined with the symmetric-merge reply-target redirect (see "Reply target rule" above), this is what closes the present-tense "stuck spinner" UX behavior that pre-merge code paths produced when AOSP canonicalized the outgoing message into a non-displayed sibling thread.
 
 ### New Messages
 

--- a/docs/SMS.md
+++ b/docs/SMS.md
@@ -61,6 +61,27 @@ Important details:
   - **Fallback**: `phone_deadline` expires with `received <= 1` — used if the daemon doesn't re-emit `conversationLoaded` (e.g. the phone added no new UIDs, or a signal-ordering race). Narrow gate kept here on purpose: if no duplicate fired, retry against an unchanged store would just re-deliver what we already have.
   The retry uses `requestConversation(threadId, received, received + page)` — same offset shape as KDE Connect's `ConversationModel::requestMoreMessages`. The resulting per-message signals merge via `known_message_ids` dedup in `app.rs`.
 
+### Reaction-Thread Merging
+
+iOS reactions over SMS arrive on slightly different address-sets and AOSP buckets them into a separate `threadId`. The phone re-merges visually; KDE Connect / Connected report them separately. Connected wraps each user-perceived conversation in a `LogicalConversation` (`sms/logical.rs`) that may collapse multiple underlying SMS threadIds.
+
+Merging precondition (`is_reaction_bucket`):
+
+- both `sub_id`s are non-`-1` and equal, AND
+- canonical address-sets are equal (digit-only normalize, leading-`1` stripped, deduplicated as a set).
+
+Each `LogicalConversation` carries:
+
+- `primary_thread_id` — the most-recently-active sibling within the merged set; used as the reply target (M9) and notification dedup key (M12).
+- `merged_thread_ids` — all underlying threadIds composing this logical conversation. Always contains `primary_thread_id`. Single-element for non-merged.
+
+Opening a merged conversation fans out the message subscription: one `conversation_message_subscription` per underlying threadId, each firing its own `requestConversation` and emitting `ConversationMessageReceived` for its own thread. Signal handlers accept any thread in the open `current_merged_thread_ids` set rather than only the primary.
+
+Multi-subscription completion semantics:
+
+- `ConversationLoadComplete` is idempotent. Math (sort, `messages_has_more`, `last_seen_sms`) always runs; loading-state clear and scroll-to-bottom snap fire only on the first arrival. Late completions silently refresh stats so a slow-completing subscription can't yank the user back to bottom.
+- `messages_has_more` math forces a heuristic-only branch when `current_merged_thread_ids.len() > 1`, since per-thread `total_count` is incomparable to the union `messages.len()`.
+
 ### Older Message Loading
 
 Older messages are loaded automatically when the user scrolls near the top of the thread.
@@ -68,6 +89,8 @@ Older messages are loaded automatically when the user scrolls near the top of th
 - Scroll position and content height are captured before the fetch.
 - Older messages are prepended when they arrive.
 - Scroll offset is adjusted so the user stays anchored near the same visible messages.
+
+For merged conversations, scroll prefetch fires only against `primary_thread_id`. Older messages from secondary `merged_thread_ids` are not backfilled on scroll. Captured smoke-test cases (NM, FH, Pair 1) have all user-visible orphaned reactions within `messages_per_page = 50` of the open, so initial-load fan-out covers them. Fanning out scroll prefetch is a deferred follow-up.
 
 ## Sending Behavior
 
@@ -115,6 +138,7 @@ Caching behavior:
 - Reply sending still depends on daemon cache priming before `replyToConversation` can work reliably.
 - Group-message behavior remains subject to KDE Connect limitations documented in `docs/KNOWN_ISSUES.md`.
 - Notification correctness depends on careful `last_seen_sms` handling when opening threads and merging incoming data.
+- For merged (reaction-bucket) conversations, scroll prefetch fires only against the primary threadId; older messages from secondary merged threads are not backfilled on scroll.
 
 ## Reference
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,8 @@ install:
     install -Dm0644 data/icons/hicolor/scalable/apps/{{APPID}}.svg {{icon_dir}}/{{APPID}}.svg
     install -Dm0644 data/icons/hicolor/scalable/apps/{{APPID}}-symbolic.svg {{icon_dir}}/{{APPID}}-symbolic.svg
     install -Dm0644 data/icons/hicolor/scalable/apps/{{APPID}}-disconnected-symbolic.svg {{icon_dir}}/{{APPID}}-disconnected-symbolic.svg
+    install -Dm0644 data/icons/hicolor/scalable/apps/{{APPID}}-merged-symbolic.svg {{icon_dir}}/{{APPID}}-merged-symbolic.svg
+    install -Dm0644 data/icons/hicolor/scalable/apps/{{APPID}}-split-symbolic.svg {{icon_dir}}/{{APPID}}-split-symbolic.svg
     @echo "Installed {{name}} to {{bin_dir}}"
     @echo "Installed {{APPID}}.desktop to {{app_dir}}"
     @echo ""
@@ -68,6 +70,8 @@ uninstall:
     rm -f {{icon_dir}}/{{APPID}}.svg
     rm -f {{icon_dir}}/{{APPID}}-symbolic.svg
     rm -f {{icon_dir}}/{{APPID}}-disconnected-symbolic.svg
+    rm -f {{icon_dir}}/{{APPID}}-merged-symbolic.svg
+    rm -f {{icon_dir}}/{{APPID}}-split-symbolic.svg
     @echo "Uninstalled {{name}}"
     @echo "Restart cosmic-panel to remove from panel: killall cosmic-panel"
 

--- a/kdeconnect-dbus/src/plugins/sms.rs
+++ b/kdeconnect-dbus/src/plugins/sms.rs
@@ -226,6 +226,12 @@ pub struct ConversationSummary {
     pub unread: bool,
     /// Whether the last message has MMS attachments.
     pub has_attachments: bool,
+    /// SIM subscription ID from the latest message in the conversation
+    /// (`-1` if untracked, e.g. older messages predating subID tracking).
+    /// Required by the reaction-bucket merge heuristic to enforce dual-SIM
+    /// safety: two threads with the same canonical address-set are only
+    /// merged when their `sub_id` values match.
+    pub sub_id: i64,
 }
 
 /// Helper to extract a string from a Value.
@@ -416,6 +422,7 @@ pub fn parse_conversations(values: Vec<OwnedValue>) -> Vec<ConversationSummary> 
             timestamp: msg.date,
             unread: !msg.read,
             has_attachments,
+            sub_id: msg.sub_id,
         });
 
         // Limit to most recent conversations


### PR DESCRIPTION
 **Topic 1 — Internal refactor.** ~1,300 LOC of SMS state and logic moved out of `app.rs` into `sms/store.rs`
  (`SmsConversationStore`). `app.rs` shrinks from ~2,873 to ~1,530 lines. Behavior parity throughout Phase 1 (M1–M5).

  **Topic 2 — Reaction-thread merging.** iOS reaction-over-SMS no longer splits a conversation into sibling threads in
   the UI:
  - `LogicalConversation` wraps one or more underlying threadIds with a validated `is_reaction_bucket` heuristic
  (canonical address-set + `subID`).
  - Multi-thread message subscription so reactions land alongside the messages they target.
  - Split-by-case reply rule (M9): symmetric merges redirect to `primary_thread_id`, sidestepping a recipient-side
  duplicate-delivery bug confirmed empirically against captured Pair 4 (1055↔58).
  - Settings + SMS-view header toggle (default ON), sharing state via `config.merge_reaction_threads`.
  - Subtle per-entry merge/split markers for observability.

  Phase 1 milestones (M1–M5) are reachable from this branch's history because Phase 2 was cut from the M5 tip; merging
   here folds in both phases.

  M11 (read-status fan-out) and M12 (notification dedup keying) deferred to v0.6.0+ — see plan doc for rationale.

  ### Verification

  - [ X] `cargo clippy --all-targets -- -D warnings` clean
  - [ X] `cargo test` green (34 tests in `cosmic-ext-connected`)
  - [ X] Final smoke test (per plan): Phase 1A pairs render merged with marker; Pair 4 reply with merge ON delivers 1
  copy; toggle off splits correctly with split markers; toggle persists across restart